### PR TITLE
feat: add deriveContextHash API for deterministic secret derivation

### DIFF
--- a/apps/extension/src/_locales/en/messages.json
+++ b/apps/extension/src/_locales/en/messages.json
@@ -1991,6 +1991,18 @@
   "sign_and_pay": {
     "message": "Sign & Pay"
   },
+  "derive_context_hash_request": {
+    "message": "Generate Identifier"
+  },
+  "derive_context_hash_description": {
+    "message": "This site is requesting a unique identifier tied to your wallet for the following context."
+  },
+  "derive_context_hash_context": {
+    "message": "Context"
+  },
+  "derive_context_hash_warning": {
+    "message": "Only approve if you trust this site."
+  },
   "sign_data_request": {
     "message": "Sign Data request"
   },

--- a/apps/extension/src/_locales/fr/messages.json
+++ b/apps/extension/src/_locales/fr/messages.json
@@ -1967,6 +1967,18 @@
   "sign_and_pay": {
     "message": "Signer & Payer"
   },
+  "derive_context_hash_request": {
+    "message": "Générer un identifiant"
+  },
+  "derive_context_hash_description": {
+    "message": "Ce site demande un identifiant unique lié à votre portefeuille pour le contexte suivant."
+  },
+  "derive_context_hash_context": {
+    "message": "Contexte"
+  },
+  "derive_context_hash_warning": {
+    "message": "N'approuvez que si vous faites confiance à ce site."
+  },
   "sign_data_request": {
     "message": "Demande de signature de données"
   },

--- a/apps/extension/src/_locales/ja/messages.json
+++ b/apps/extension/src/_locales/ja/messages.json
@@ -1967,6 +1967,18 @@
   "sign_and_pay": {
     "message": "署名して支払う"
   },
+  "derive_context_hash_request": {
+    "message": "識別子を生成"
+  },
+  "derive_context_hash_description": {
+    "message": "このサイトは、以下のコンテキストに対してウォレットに紐づく一意の識別子を要求しています。"
+  },
+  "derive_context_hash_context": {
+    "message": "コンテキスト"
+  },
+  "derive_context_hash_warning": {
+    "message": "このサイトを信頼できる場合のみ承認してください。"
+  },
   "sign_data_request": {
     "message": "データ署名リクエスト"
   },

--- a/apps/extension/src/_locales/ru/messages.json
+++ b/apps/extension/src/_locales/ru/messages.json
@@ -1967,6 +1967,18 @@
   "sign_and_pay": {
     "message": "Подписать и оплатить"
   },
+  "derive_context_hash_request": {
+    "message": "Сгенерировать идентификатор"
+  },
+  "derive_context_hash_description": {
+    "message": "Этот сайт запрашивает уникальный идентификатор, привязанный к вашему кошельку, для следующего контекста."
+  },
+  "derive_context_hash_context": {
+    "message": "Контекст"
+  },
+  "derive_context_hash_warning": {
+    "message": "Одобряйте только если вы доверяете этому сайту."
+  },
   "sign_data_request": {
     "message": "Запрос подписи данных"
   },

--- a/apps/extension/src/_locales/zh_TW/messages.json
+++ b/apps/extension/src/_locales/zh_TW/messages.json
@@ -1970,6 +1970,18 @@
   "sign_and_pay": {
     "message": "簽署並支付"
   },
+  "derive_context_hash_request": {
+    "message": "產生識別碼"
+  },
+  "derive_context_hash_description": {
+    "message": "此網站正在請求一個與您的錢包綁定的唯一識別碼，用於以下上下文。"
+  },
+  "derive_context_hash_context": {
+    "message": "上下文"
+  },
+  "derive_context_hash_warning": {
+    "message": "僅在您信任此網站時才批准。"
+  },
   "sign_data_request": {
     "message": "簽署資料請求"
   },

--- a/apps/extension/src/content-script/pageProvider/bitcoinAPI.ts
+++ b/apps/extension/src/content-script/pageProvider/bitcoinAPI.ts
@@ -3,6 +3,7 @@
  * Handles Bitcoin-related functionality
  */
 import {
+  RequestMethodDeriveContextHashParams,
   RequestMethodGetBitcoinUtxosParams,
   RequestMethodGetInscriptionsParams,
   RequestMethodInscribeTransferParams,
@@ -246,6 +247,16 @@ export class BitcoinAPIMethods {
   getVersion = async () => {
     return this.provider[requestMethodKey]({
       method: 'getVersion'
+    });
+  };
+
+  deriveContextHash = async (context: string) => {
+    const params: RequestMethodDeriveContextHashParams = {
+      context
+    };
+    return this.provider[requestMethodKey]({
+      method: 'deriveContextHash',
+      params
     });
   };
 

--- a/apps/extension/src/content-script/pageProvider/index.ts
+++ b/apps/extension/src/content-script/pageProvider/index.ts
@@ -83,6 +83,7 @@ export class UnisatProvider extends EventEmitter {
   pushPsbt = async (psbtHex: string) => this.bitcoinAPI.pushPsbt(psbtHex);
   inscribeTransfer = async (ticker: string, amount: string) => this.bitcoinAPI.inscribeTransfer(ticker, amount);
   getVersion = async () => this.bitcoinAPI.getVersion();
+  deriveContextHash = async (context: string) => this.bitcoinAPI.deriveContextHash(context);
   getBitcoinUtxos = async (cursor = 0, size = 20) => this.bitcoinAPI.getBitcoinUtxos(cursor, size);
 }
 

--- a/apps/extension/src/ui/pages/Approval/components/DeriveContextHash.tsx
+++ b/apps/extension/src/ui/pages/Approval/components/DeriveContextHash.tsx
@@ -1,0 +1,85 @@
+import {
+  Button,
+  Card,
+  Column,
+  Content,
+  Footer,
+  Header,
+  Layout,
+  Row,
+  Text
+} from '@/ui/components';
+import WebsiteBar from '@/ui/components/WebsiteBar';
+import { useApproval, useI18n } from '@unisat/wallet-state';
+
+interface Props {
+  params: {
+    data: {
+      context: string;
+    };
+    session: {
+      origin: string;
+      icon: string;
+      name: string;
+    };
+  };
+}
+
+export default function DeriveContextHash({ params: { data, session } }: Props) {
+  const { resolveApproval, rejectApproval } = useApproval();
+  const { t } = useI18n();
+
+  const handleCancel = () => {
+    rejectApproval();
+  };
+
+  const handleConfirm = () => {
+    resolveApproval();
+  };
+
+  return (
+    <Layout>
+      <Content>
+        <Header>
+          <WebsiteBar session={session} />
+        </Header>
+
+        <Column>
+          <Text text={t('derive_context_hash_request')} preset="title-bold" textCenter mt="lg" />
+
+          <Text text={t('derive_context_hash_description')} textCenter mt="lg" />
+
+          <Text text={t('derive_context_hash_context')} preset="bold" mt="lg" />
+          <Card>
+            <div
+              style={{
+                userSelect: 'text',
+                maxHeight: 384,
+                overflow: 'auto',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-all',
+                fontFamily: 'monospace'
+              }}>
+              {data.context}
+            </div>
+          </Card>
+
+          <Text
+            preset="sub"
+            textCenter
+            mt="lg"
+            color="warning"
+            text={t('derive_context_hash_warning')}
+          />
+        </Column>
+      </Content>
+
+      <Footer>
+        <Row full>
+          <Button text={t('reject')} full preset="default" onClick={handleCancel} />
+          <Button text={t('confirm')} full preset="primary" onClick={handleConfirm} />
+        </Row>
+      </Footer>
+    </Layout>
+  );
+}

--- a/apps/extension/src/ui/pages/Approval/components/index.ts
+++ b/apps/extension/src/ui/pages/Approval/components/index.ts
@@ -1,5 +1,6 @@
 export { default as Connect } from './Connect';
 export { default as CosmosConnect } from './CosmosConnect';
+export { default as DeriveContextHash } from './DeriveContextHash';
 export { default as CosmosSign } from './CosmosSign';
 export { default as InscribeTransfer } from './InscribeTransfer';
 export { default as SignData } from './SignData';

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -18,6 +18,7 @@ The `window.unisat` object is injected by the UniSat Wallet extension into every
 | [Address Types](./address-types.md) | Supported address formats |
 | [Manage Assets](./manage-assets.md) | Send BTC, inscriptions, Runes, BRC-20 |
 | [Manage Networks](./manage-networks.md) | Switch networks, listen for changes |
+| [Derive Context Hash](./derive-context-hash.md) | Deterministic secret derivation from wallet seed |
 | [Sign Message](./sign-message.md) | BIP-322 and ECDSA message signing |
 | [Sign Transaction](./sign-transaction.md) | PSBT signing and transaction broadcasting |
 | [Mobile Integration](./mobile-integration.md) | Deep-link integration for mobile dApps |

--- a/docs/api/derive-context-hash.md
+++ b/docs/api/derive-context-hash.md
@@ -1,0 +1,63 @@
+# Derive Context Hash
+
+### deriveContextHash
+
+```
+unisat.deriveContextHash(context)
+```
+
+Derive a deterministic 32-byte value from the wallet's key material and an arbitrary context string. The derivation uses HKDF-SHA-256 (RFC 5869), a formally proven key derivation function.
+
+**Requires user approval** — the wallet will show a confirmation dialog displaying the context string before deriving the value.
+
+**Supported keyring types**: HD wallets (mnemonic), HD wallets (xpriv), and imported private keys.
+
+**Parameters**
+
+- `context` - `string`: A hex-encoded context string (even-length, e.g. `"deadbeef0123"`). The context acts as a domain separator — different contexts produce different, independent outputs.
+
+**Returns**
+
+- `Promise` - `string`: Hex-encoded 32-byte derived value (64 hex characters).
+
+**Derivation Scheme**
+
+```
+HKDF-SHA-256(ikm=keyMaterial, salt="unisat-derive-context-hash", info=context, length=32)
+```
+
+Where `keyMaterial` is:
+- The 64-byte BIP-39 seed (for mnemonic-based wallets), or
+- The 32-byte private key (for imported key or xpriv wallets).
+
+---
+
+**Example**
+
+```javascript
+try {
+  // Context is a hex-encoded string (e.g., vault_id + public_key)
+  const context = "a1b2c3d4e5f6...";
+  const hash = await window.unisat.deriveContextHash(context);
+  console.log(hash);
+  // => "16fa55f8a70ecc973e6baa1ffd77cd1db7bf019d78de4310f0011cc201007c02"
+} catch (e) {
+  console.log(e);
+}
+```
+
+---
+
+**Security**
+
+- HKDF is a formally proven extract-then-expand KDF (Krawczyk, Crypto 2010; RFC 5869).
+- The Extract step ensures even structured inputs (e.g., secp256k1 keys) produce a uniformly random pseudorandom key.
+- The Expand step is a PRF — revealing many outputs for different contexts does not leak the seed or private key.
+- The fixed salt `"unisat-derive-context-hash"` provides domain separation from BIP-32 and other HMAC uses.
+- All intermediate key material is zeroed after use within the wallet.
+- Used by TLS 1.3, Signal Protocol, and Ethereum EIP-2333 for similar key derivation purposes.
+
+**Use Cases**
+
+- **HTLC preimages**: Derive a deterministic secret `s` for atomic swap flows. Commit `SHA256(s)` on-chain, reveal `s` later.
+- **Deterministic key generation**: Use the output as seed material for application-specific cryptographic schemes (e.g., Lamport signatures).

--- a/packages/keyring-service/README.md
+++ b/packages/keyring-service/README.md
@@ -133,6 +133,10 @@ Main service class for managing keyrings.
 - `signMessage(address: string, keyringType: string, message: string): Promise<string>` - Sign message
 - `verifyMessage(address: string, message: string, signature: string): Promise<boolean>` - Verify message
 
+##### Key Derivation
+
+- `deriveContextHash(publicKey: string, context: string): Promise<string>` - Derive a deterministic 32-byte value from the wallet's key material and a hex-encoded context string using HKDF-SHA-256 (RFC 5869). Supported by all keyring types: HD (mnemonic), HD (xpriv), and imported private keys.
+
 ### Types
 
 ```typescript

--- a/packages/keyring-service/package.json
+++ b/packages/keyring-service/package.json
@@ -52,6 +52,7 @@
     "@unisat/wallet-shared": "workspace:*",
     "@unisat/wallet-storage": "workspace:*",
     "@unisat/wallet-types": "workspace:*",
+    "@noble/hashes": "^1.3.0",
     "bip39": "^3.1.0",
     "bitcoinjs-lib": "^6.1.5",
     "bitcore-lib": "^10.0.0",

--- a/packages/keyring-service/src/keyrings/derive-context-hash.ts
+++ b/packages/keyring-service/src/keyrings/derive-context-hash.ts
@@ -1,0 +1,87 @@
+/**
+ * Deterministic context-based key derivation using HKDF (RFC 5869).
+ *
+ * Derives a 32-byte pseudorandom value from either:
+ * - A 64-byte BIP-39 seed (mnemonic-based keyrings), or
+ * - A 32-byte private key (imported key keyrings), expanded via HKDF first.
+ *
+ * ## Derivation scheme
+ *
+ * ```
+ * HKDF-SHA-256(ikm=keyMaterial, salt="unisat-derive-context-hash", info=context, length=32)
+ * ```
+ *
+ * Where `keyMaterial` is either the full 64-byte BIP-39 seed or a 32-byte
+ * private key. HKDF-Extract produces a pseudorandom key (PRK) from the input,
+ * and HKDF-Expand derives the output keyed on the context.
+ *
+ * ## Security
+ *
+ * - HKDF is a formally proven extract-then-expand KDF (Krawczyk, Crypto 2010).
+ * - The Extract step ensures that even structured input (e.g. secp256k1 keys
+ *   constrained to < curve order) produces a uniformly random PRK.
+ * - The Expand step is a PRF; revealing outputs for many different contexts
+ *   does not leak the PRK, seed, or any BIP-32 private keys.
+ * - A fixed salt provides domain separation from BIP-32 and other HMAC uses.
+ * - All intermediate key material is zeroed after use.
+ * - Safe to reveal up to 2^256 outputs (birthday bound of HMAC-SHA-256).
+ *
+ * @module derive-context-hash
+ */
+
+import { hkdf } from '@noble/hashes/hkdf'
+import { sha256 } from '@noble/hashes/sha256'
+
+const SALT = 'unisat-derive-context-hash'
+const OUTPUT_LENGTH = 32
+
+/**
+ * Convert a Uint8Array to a hex string.
+ */
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/**
+ * Derive a deterministic 32-byte value from key material and a context.
+ *
+ * @param ikm     - Input key material: 64-byte BIP-39 seed or 32-byte private key.
+ * @param context - Arbitrary context bytes (caller-defined domain separator).
+ * @returns Hex-encoded 32-byte derived value.
+ */
+export function deriveContextHash(ikm: Uint8Array, context: Uint8Array): string {
+  if (ikm.length !== 64 && ikm.length !== 32) {
+    throw new Error(`Input key material must be 32 or 64 bytes, got ${ikm.length}`)
+  }
+
+  const derived = hkdf(sha256, ikm, SALT, context, OUTPUT_LENGTH)
+  const result = toHex(derived)
+
+  // Zero intermediate material
+  derived.fill(0)
+
+  return result
+}
+
+/**
+ * Parse a hex-encoded context string into a Uint8Array.
+ * Validates that the input is a non-empty, even-length hex string.
+ */
+export function parseHexContext(context: string): Uint8Array {
+  if (!context || context.length === 0) {
+    throw new Error('Context must be a non-empty string')
+  }
+  if (context.length % 2 !== 0) {
+    throw new Error('Context must be an even-length hex string')
+  }
+  if (!/^[0-9a-fA-F]+$/.test(context)) {
+    throw new Error('Context must be a valid hex string')
+  }
+  const bytes = new Uint8Array(context.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(context.substring(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}

--- a/packages/keyring-service/src/keyrings/hd-keyring.ts
+++ b/packages/keyring-service/src/keyrings/hd-keyring.ts
@@ -5,6 +5,7 @@ import bitcore from 'bitcore-lib'
 import * as hdkey from 'hdkey'
 
 import { ECPairInterface, bitcoin, eccManager } from '@unisat/wallet-bitcoin'
+import { deriveContextHash, parseHexContext } from './derive-context-hash'
 import { SimpleKeyring } from './simple-keyring'
 
 const hdPathString = "m/44'/0'/0'/0"
@@ -259,6 +260,39 @@ export class HdKeyring extends SimpleKeyring {
       }
     }
     return null
+  }
+
+  /**
+   * Derive a deterministic context hash from the wallet's key material.
+   * Uses the 64-byte BIP-39 seed for mnemonic keyrings, or the xpriv
+   * root private key (32 bytes) for xpriv-only keyrings.
+   *
+   * @param publicKey - Public key identifying the account (unused for HD keyrings
+   *   since derivation is from the root, but kept for interface consistency).
+   * @param context - Hex-encoded context string.
+   * @returns Hex-encoded 32-byte derived value (64 hex characters).
+   */
+  override async deriveContextHash(_publicKey: string, context: string): Promise<string> {
+    const contextBytes = parseHexContext(context)
+    if (this.mnemonic) {
+      const seedBuf = bip39.mnemonicToSeedSync(this.mnemonic, this.passphrase)
+      const seed = new Uint8Array(seedBuf.buffer, seedBuf.byteOffset, seedBuf.byteLength)
+      try {
+        return deriveContextHash(seed, contextBytes)
+      } finally {
+        seed.fill(0)
+      }
+    }
+    // xpriv-only: use the root xpriv private key
+    if (this.root && this.root.privateKey) {
+      const privKeyBytes = new Uint8Array(this.root.privateKey)
+      try {
+        return deriveContextHash(privKeyBytes, contextBytes)
+      } finally {
+        privKeyBytes.fill(0)
+      }
+    }
+    throw new Error('deriveContextHash requires a mnemonic or xpriv-based keyring')
   }
 
   private _addressFromIndex(i: number) {

--- a/packages/keyring-service/src/keyrings/simple-keyring.ts
+++ b/packages/keyring-service/src/keyrings/simple-keyring.ts
@@ -10,6 +10,7 @@ import { isTaprootInput } from 'bitcoinjs-lib/src/psbt/bip371.js'
 import { decode } from 'bs58check'
 import { EventEmitter } from 'events'
 import { ToSignInput } from '../types'
+import { deriveContextHash, parseHexContext } from './derive-context-hash'
 
 const type = 'Simple Key Pair'
 
@@ -125,6 +126,20 @@ export class SimpleKeyring extends EventEmitter {
     }
 
     this.wallets = this.wallets.filter(wallet => wallet.publicKey.toString('hex') !== publicKey)
+  }
+
+  async deriveContextHash(publicKey: string, context: string): Promise<string> {
+    const wallet = this._getWalletForAccount(publicKey)
+    if (!wallet.privateKey) {
+      throw new Error('deriveContextHash requires access to the private key')
+    }
+    const contextBytes = parseHexContext(context)
+    const privKeyBytes = new Uint8Array(wallet.privateKey)
+    try {
+      return deriveContextHash(privKeyBytes, contextBytes)
+    } finally {
+      privKeyBytes.fill(0)
+    }
   }
 
   private _getWalletForAccount(publicKey: string) {

--- a/packages/keyring-service/src/types/keyring.ts
+++ b/packages/keyring-service/src/types/keyring.ts
@@ -39,6 +39,7 @@ export interface Keyring {
 
   changeHdPath?(hdPath: string): void
   getAccountByHdPath?(hdPath: string, index: number): string
+  deriveContextHash?(publicKey: string, context: string): Promise<string>
 
   // Keystone specific methods
   genSignPsbtUr?(psbtHex: string): Promise<{ type: string; cbor: string }>

--- a/packages/keyring-service/test/derive-context-hash.test.ts
+++ b/packages/keyring-service/test/derive-context-hash.test.ts
@@ -1,0 +1,192 @@
+import * as bip39 from 'bip39'
+import { describe, expect, it } from 'vitest'
+
+import { deriveContextHash, parseHexContext } from '../src/keyrings/derive-context-hash'
+
+const KNOWN_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+
+const SAMPLE_MNEMONIC =
+  'finish oppose decorate face calm tragic certain desk hour urge dinosaur mango'
+
+function freshSeed(): Uint8Array {
+  const seed = bip39.mnemonicToSeedSync(KNOWN_MNEMONIC)
+  return new Uint8Array(seed.buffer, seed.byteOffset, seed.byteLength)
+}
+
+describe('deriveContextHash', () => {
+  describe('output format', () => {
+    it('returns a 64-character hex string (32 bytes) for 64-byte seed', () => {
+      const ctx = Buffer.from('test-context', 'utf-8')
+      const result = deriveContextHash(freshSeed(), ctx)
+      expect(result).toHaveLength(64)
+      expect(result).toMatch(/^[0-9a-f]{64}$/)
+    })
+
+    it('returns a 64-character hex string (32 bytes) for 32-byte key', () => {
+      const ctx = Buffer.from('test-context', 'utf-8')
+      const key = new Uint8Array(32).fill(0xab)
+      const result = deriveContextHash(key, ctx)
+      expect(result).toHaveLength(64)
+      expect(result).toMatch(/^[0-9a-f]{64}$/)
+    })
+  })
+
+  describe('determinism', () => {
+    it('produces identical results for same seed + context', () => {
+      const ctx = Buffer.from('test-context', 'utf-8')
+      const a = deriveContextHash(freshSeed(), ctx)
+      const b = deriveContextHash(freshSeed(), ctx)
+      expect(a).toBe(b)
+    })
+
+    it('produces identical results for same 32-byte key + context', () => {
+      const ctx = Buffer.from('test-context', 'utf-8')
+      const key = new Uint8Array(32).fill(0xab)
+      const a = deriveContextHash(key, ctx)
+      const b = deriveContextHash(key, ctx)
+      expect(a).toBe(b)
+    })
+  })
+
+  describe('context differentiation', () => {
+    it('produces different results for different contexts', () => {
+      const ctx1 = Buffer.from('context-1', 'utf-8')
+      const ctx2 = Buffer.from('context-2', 'utf-8')
+      const a = deriveContextHash(freshSeed(), ctx1)
+      const b = deriveContextHash(freshSeed(), ctx2)
+      expect(a).not.toBe(b)
+    })
+
+    it('produces different results for empty vs non-empty context', () => {
+      const empty = new Uint8Array(0)
+      const nonempty = Buffer.from('x', 'utf-8')
+      const a = deriveContextHash(freshSeed(), empty)
+      const b = deriveContextHash(freshSeed(), nonempty)
+      expect(a).not.toBe(b)
+    })
+  })
+
+  describe('input validation', () => {
+    it('rejects key material that is not 32 or 64 bytes', () => {
+      const ctx = Buffer.from('test', 'utf-8')
+      expect(() => deriveContextHash(new Uint8Array(16), ctx)).toThrow(
+        'Input key material must be 32 or 64 bytes, got 16'
+      )
+      expect(() => deriveContextHash(new Uint8Array(48), ctx)).toThrow(
+        'Input key material must be 32 or 64 bytes, got 48'
+      )
+      expect(() => deriveContextHash(new Uint8Array(128), ctx)).toThrow(
+        'Input key material must be 32 or 64 bytes, got 128'
+      )
+    })
+  })
+
+  describe('seed vs private key isolation', () => {
+    it('32-byte key and 64-byte seed produce different results for same context', () => {
+      const ctx = Buffer.from('test-context', 'utf-8')
+      const seed = freshSeed()
+      const key32 = seed.slice(0, 32) // first 32 bytes of seed
+      const a = deriveContextHash(seed, ctx)
+      const b = deriveContextHash(key32, ctx)
+      expect(a).not.toBe(b)
+    })
+  })
+
+  describe('binary context edge cases', () => {
+    it('handles all-zero context', () => {
+      const ctx = new Uint8Array(32)
+      const result = deriveContextHash(freshSeed(), ctx)
+      expect(result).toHaveLength(64)
+      expect(result).toMatch(/^[0-9a-f]{64}$/)
+    })
+
+    it('handles all-0xff context', () => {
+      const ctx = new Uint8Array(32).fill(0xff)
+      const result = deriveContextHash(freshSeed(), ctx)
+      expect(result).toHaveLength(64)
+      expect(result).toMatch(/^[0-9a-f]{64}$/)
+    })
+
+    it('handles large context (10KB)', () => {
+      const ctx = new Uint8Array(10240).fill(0xab)
+      const result = deriveContextHash(freshSeed(), ctx)
+      expect(result).toHaveLength(64)
+      expect(result).toMatch(/^[0-9a-f]{64}$/)
+    })
+
+    it('all-zero and all-0xff contexts produce different results', () => {
+      const zeros = deriveContextHash(freshSeed(), new Uint8Array(32))
+      const ones = deriveContextHash(freshSeed(), new Uint8Array(32).fill(0xff))
+      expect(zeros).not.toBe(ones)
+    })
+  })
+
+  describe('different mnemonics', () => {
+    it('produces different results for different seeds with same context', () => {
+      const ctx = Buffer.from('test-context', 'utf-8')
+      const seed1 = freshSeed()
+      const seed2Buf = bip39.mnemonicToSeedSync(SAMPLE_MNEMONIC)
+      const seed2 = new Uint8Array(seed2Buf.buffer, seed2Buf.byteOffset, seed2Buf.byteLength)
+      const a = deriveContextHash(seed1, ctx)
+      const b = deriveContextHash(seed2, ctx)
+      expect(a).not.toBe(b)
+    })
+  })
+
+  describe('known-answer tests (HKDF-SHA-256)', () => {
+    it('produces a stable output for regression detection', () => {
+      const ctx = Buffer.from('babylon-vault-test', 'utf-8')
+      const result = deriveContextHash(freshSeed(), ctx)
+      // Pinned value — if this changes, the derivation scheme has changed
+      expect(result).toBe('16fa55f8a70ecc973e6baa1ffd77cd1db7bf019d78de4310f0011cc201007c02')
+    })
+
+    it('produces a stable output for a second context', () => {
+      const ctx = Buffer.from('babylon-htlc-preimage', 'utf-8')
+      const result = deriveContextHash(freshSeed(), ctx)
+      // Second pinned value for broader regression coverage
+      expect(result).toBe('471e93f5b1964fde6cde9e83e8277f2268654a9a4178c775f8bf2912843e92ac')
+    })
+
+    it('produces a stable output for 32-byte private key', () => {
+      const privKey = Buffer.from('69f477943dd1591f0261cabade0839e2ffc0c13d8fa1ce0d69f6c6c251163b34', 'hex')
+      const ctx = Buffer.from('deadbeef', 'hex')
+      const result = deriveContextHash(new Uint8Array(privKey), ctx)
+      expect(result).toBe('98263601b05e6d8e71e901d4f96ec4a23634ef17a7f26ee2f6dae3634f5f62c1')
+    })
+  })
+})
+
+// Note: HdKeyring integration tests are in hd-keyring.test.ts
+// because HdKeyring imports @unisat/wallet-bitcoin which requires the package to be built first.
+// SimpleKeyring integration tests are in simple-keyring.test.ts.
+
+describe('parseHexContext', () => {
+  it('parses valid hex string', () => {
+    const result = parseHexContext('deadbeef')
+    expect(result).toEqual(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))
+  })
+
+  it('handles uppercase hex', () => {
+    const result = parseHexContext('DEADBEEF')
+    expect(result).toEqual(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))
+  })
+
+  it('handles mixed case hex', () => {
+    const result = parseHexContext('DeAdBeEf')
+    expect(result).toEqual(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))
+  })
+
+  it('rejects empty string', () => {
+    expect(() => parseHexContext('')).toThrow('non-empty')
+  })
+
+  it('rejects odd-length hex', () => {
+    expect(() => parseHexContext('abc')).toThrow('even-length')
+  })
+
+  it('rejects non-hex characters', () => {
+    expect(() => parseHexContext('xyz123')).toThrow('valid hex')
+  })
+})

--- a/packages/keyring-service/test/hd-keyring.test.ts
+++ b/packages/keyring-service/test/hd-keyring.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { deriveContextHash, parseHexContext } from '../src/keyrings/derive-context-hash'
 import { HdKeyring } from '../src/keyrings/hd-keyring'
 const sampleMnemonic =
   'finish oppose decorate face calm tragic certain desk hour urge dinosaur mango'
@@ -281,6 +282,115 @@ describe('bitcoin-hd-keyring', () => {
       const accounts = await keyring.getAccounts()
       expect(accounts[0]).eq('02d16db9d525d8623e80c04e33c4463450285791124381bc545bb85e5e8925a776') // m/84'/0'/0'/0/0
       expect(accounts[1]).eq('023f0b3115a6c5a51ec62d8cbe6e834e79fe4bf22555e095a163e0e451a6fdc4d5') // m/84'/0'/0'/0/1
+    })
+  })
+
+  describe('deriveContextHash', () => {
+    it('derives context hash with mnemonic-based keyring', async () => {
+      const keyring = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        activeIndexes: [0],
+      })
+      const accounts = await keyring.getAccounts()
+      const result = await keyring.deriveContextHash(accounts[0], 'deadbeef')
+      expect(result).toHaveLength(64)
+      expect(result).toMatch(/^[0-9a-f]{64}$/)
+    })
+
+    it('produces same result as direct derivation', async () => {
+      const keyring = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        activeIndexes: [0],
+      })
+      const accounts = await keyring.getAccounts()
+      const contextHex = 'deadbeef'
+      const keyringResult = await keyring.deriveContextHash(accounts[0], contextHex)
+
+      const bip39 = await import('bip39')
+      const seedBuf = bip39.mnemonicToSeedSync(sampleMnemonic)
+      const seed = new Uint8Array(seedBuf.buffer, seedBuf.byteOffset, seedBuf.byteLength)
+      const directResult = deriveContextHash(seed, parseHexContext(contextHex))
+      expect(keyringResult).toBe(directResult)
+    })
+
+    it('mnemonic keyring produces same result regardless of which account pubkey is passed', async () => {
+      const keyring = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        activeIndexes: [0, 1],
+      })
+      const accounts = await keyring.getAccounts()
+      const result0 = await keyring.deriveContextHash(accounts[0], 'deadbeef')
+      const result1 = await keyring.deriveContextHash(accounts[1], 'deadbeef')
+      // HD keyring derives from the root seed, not individual account keys
+      expect(result0).toBe(result1)
+    })
+
+    it('xpriv-only keyring uses root private key', async () => {
+      const sampleXpriv =
+        'xprvA2JBuYsdqVhrC2wGmb9QhBejk9gXXYgM3Jg9xgVYmDMsakDoURc8V7UYos1pP1kev1tG51PPA9A8VMYYCLov1L5c3J7npraxwjeJCquGhDi'
+      const keyring = new HdKeyring({
+        xpriv: sampleXpriv,
+        activeIndexes: [0],
+      })
+      const accounts = await keyring.getAccounts()
+      const result = await keyring.deriveContextHash(accounts[0], 'deadbeef')
+      expect(result).toHaveLength(64)
+      expect(result).toMatch(/^[0-9a-f]{64}$/)
+    })
+
+    it('mnemonic and xpriv produce different results for same context', async () => {
+      const sampleXpriv =
+        'xprvA2JBuYsdqVhrC2wGmb9QhBejk9gXXYgM3Jg9xgVYmDMsakDoURc8V7UYos1pP1kev1tG51PPA9A8VMYYCLov1L5c3J7npraxwjeJCquGhDi'
+      const mnemonicKeyring = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        activeIndexes: [0],
+      })
+      const xprivKeyring = new HdKeyring({
+        xpriv: sampleXpriv,
+        activeIndexes: [0],
+      })
+      const mnemonicAccounts = await mnemonicKeyring.getAccounts()
+      const xprivAccounts = await xprivKeyring.getAccounts()
+      const mnemonicResult = await mnemonicKeyring.deriveContextHash(mnemonicAccounts[0], 'deadbeef')
+      const xprivResult = await xprivKeyring.deriveContextHash(xprivAccounts[0], 'deadbeef')
+      expect(mnemonicResult).not.toBe(xprivResult)
+    })
+
+    it('xpriv result is stable regardless of account activation order', async () => {
+      const sampleXpriv =
+        'xprvA2JBuYsdqVhrC2wGmb9QhBejk9gXXYgM3Jg9xgVYmDMsakDoURc8V7UYos1pP1kev1tG51PPA9A8VMYYCLov1L5c3J7npraxwjeJCquGhDi'
+      const keyring1 = new HdKeyring({
+        xpriv: sampleXpriv,
+        activeIndexes: [0, 1],
+      })
+      const keyring2 = new HdKeyring({
+        xpriv: sampleXpriv,
+        activeIndexes: [1, 0],
+      })
+      const accounts1 = await keyring1.getAccounts()
+      const accounts2 = await keyring2.getAccounts()
+      const result1 = await keyring1.deriveContextHash(accounts1[0], 'deadbeef')
+      const result2 = await keyring2.deriveContextHash(accounts2[0], 'deadbeef')
+      // Both use root xpriv key, so results must match
+      expect(result1).toBe(result2)
+    })
+
+    it('rejects invalid hex context', async () => {
+      const keyring = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        activeIndexes: [0],
+      })
+      const accounts = await keyring.getAccounts()
+      await expect(keyring.deriveContextHash(accounts[0], 'xyz')).rejects.toThrow()
+      await expect(keyring.deriveContextHash(accounts[0], '')).rejects.toThrow()
+      await expect(keyring.deriveContextHash(accounts[0], 'abc')).rejects.toThrow()
+    })
+
+    it('rejects uninitialized keyring', async () => {
+      const keyring = new HdKeyring()
+      await expect(keyring.deriveContextHash('anypubkey', 'deadbeef')).rejects.toThrow(
+        'requires a mnemonic or xpriv-based keyring'
+      )
     })
   })
 

--- a/packages/keyring-service/test/simple-keyring.test.ts
+++ b/packages/keyring-service/test/simple-keyring.test.ts
@@ -7,6 +7,7 @@ import {
   validator,
 } from '@unisat/wallet-bitcoin'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { deriveContextHash, parseHexContext } from '../src/keyrings/derive-context-hash'
 import { SimpleKeyring } from '../src/keyrings/simple-keyring'
 
 const TYPE_STR = 'Simple Key Pair'
@@ -357,6 +358,53 @@ describe('bitcoin-simple-keyring', () => {
         }
       )
       expect(psbt.validateSignaturesOfAllInputs(validator)).to.be.true
+    })
+  })
+
+  describe('#deriveContextHash', () => {
+    it('derives a 64-char hex value', async () => {
+      const newKeyring = new SimpleKeyring([testAccount.key])
+      const result = await newKeyring.deriveContextHash(testAccount.address, 'deadbeef')
+      expect(result).toHaveLength(64)
+      expect(result).toMatch(/^[0-9a-f]{64}$/)
+    })
+
+    it('produces same result as direct derivation', async () => {
+      const newKeyring = new SimpleKeyring([testAccount.key])
+      const result = await newKeyring.deriveContextHash(testAccount.address, 'deadbeef')
+      const privKeyBytes = new Uint8Array(Buffer.from(testAccount.key, 'hex'))
+      const directResult = deriveContextHash(privKeyBytes, parseHexContext('deadbeef'))
+      expect(result).toBe(directResult)
+    })
+
+    it('known-answer test', async () => {
+      const newKeyring = new SimpleKeyring([testAccount.key])
+      const result = await newKeyring.deriveContextHash(testAccount.address, 'deadbeef')
+      expect(result).toBe('8f2064889f825ec2797ed764668b36998eebe22e682255b425edda0c2f6ed7f9')
+    })
+
+    it('different accounts produce different results', async () => {
+      const newKeyring = new SimpleKeyring()
+      await newKeyring.addAccounts(2)
+      const accounts = await newKeyring.getAccounts()
+      const result0 = await newKeyring.deriveContextHash(accounts[0], 'deadbeef')
+      const result1 = await newKeyring.deriveContextHash(accounts[1], 'deadbeef')
+      expect(result0).not.toBe(result1)
+    })
+
+    it('throws for unknown public key', async () => {
+      const newKeyring = new SimpleKeyring([testAccount.key])
+      const fakePubkey = '000000000000000000000000000000000000000000000000000000000000000000'
+      await expect(newKeyring.deriveContextHash(fakePubkey, 'deadbeef')).rejects.toThrow(
+        'Unable to find matching publicKey'
+      )
+    })
+
+    it('rejects invalid hex context', async () => {
+      const newKeyring = new SimpleKeyring([testAccount.key])
+      await expect(newKeyring.deriveContextHash(testAccount.address, 'xyz')).rejects.toThrow()
+      await expect(newKeyring.deriveContextHash(testAccount.address, '')).rejects.toThrow()
+      await expect(newKeyring.deriveContextHash(testAccount.address, 'abc')).rejects.toThrow()
     })
   })
 })

--- a/packages/wallet-background/src/controllers/provider/controller.ts
+++ b/packages/wallet-background/src/controllers/provider/controller.ts
@@ -1,5 +1,6 @@
 import { bitcoin, verifyMessageOfBIP322Simple } from '@unisat/wallet-bitcoin'
 import {
+  RequestMethodDeriveContextHashParams,
   RequestMethodGetInscriptionsParams,
   RequestMethodSendBitcoinParams,
   RequestMethodSendInscriptionParams,
@@ -535,6 +536,34 @@ class ProviderController extends BaseController {
 
     const respone = encodeSignature(approvalRes.publicKey, approvalRes.signature)
     return respone
+  }
+  @Reflect.metadata('APPROVAL', [
+    'DeriveContextHash',
+    async req => {
+      const params: RequestMethodDeriveContextHashParams = req.data.params
+      if (!params.context) {
+        throw new Error('context is required')
+      }
+      if (typeof params.context !== 'string') {
+        throw new Error('context must be a string')
+      }
+      if (params.context.length === 0) {
+        throw new Error('context must be non-empty')
+      }
+      if (params.context.length % 2 !== 0) {
+        throw new Error('context must be an even-length hex string')
+      }
+      if (!/^[0-9a-fA-F]+$/.test(params.context)) {
+        throw new Error('context must be a valid hex string')
+      }
+    },
+  ])
+  deriveContextHash = async ({
+    data: {
+      params: { context },
+    },
+  }) => {
+    return await wallet.deriveContextHash(context)
   }
 }
 

--- a/packages/wallet-background/src/controllers/provider/methodList.ts
+++ b/packages/wallet-background/src/controllers/provider/methodList.ts
@@ -40,6 +40,9 @@ export type ProviderMethodList = {
     signerAddress: string
     data: string
   }
+  deriveContextHash: {
+    context: string
+  }
 }
 
 export type ProviderMethods = keyof ProviderMethodList

--- a/packages/wallet-background/src/controllers/wallet.ts
+++ b/packages/wallet-background/src/controllers/wallet.ts
@@ -1009,6 +1009,16 @@ export class WalletController extends BaseController {
     }
   }
 
+  deriveContextHash = async (context: string): Promise<string> => {
+    const account = preferenceService.getCurrentAccount()
+    if (!account) throw new Error('no current account')
+    const keyring = await keyringService.getKeyringForAccount(account.pubkey, account.type)
+    if (!keyring.deriveContextHash) {
+      throw new Error('Current keyring does not support deriveContextHash')
+    }
+    return keyring.deriveContextHash(account.pubkey, context)
+  }
+
   addContact = (data: ContactBookItem) => {
     contactBookService.addContact(data)
   }

--- a/packages/wallet-shared/src/types/request-method.ts
+++ b/packages/wallet-shared/src/types/request-method.ts
@@ -94,3 +94,7 @@ export interface RequestMethodGetAvailableUtxosParams {
   cursor: number
   size: number
 }
+
+export interface RequestMethodDeriveContextHashParams {
+  context: string
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1328,6 +1328,28 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
 
+  packages/approval-service:
+    dependencies:
+      '@unisat/wallet-shared':
+        specifier: workspace:*
+        version: link:../wallet-shared
+      eventemitter3:
+        specifier: ^5.0.1
+        version: 5.0.1
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.8.0
+      tsup:
+        specifier: ^7.0.0
+        version: 7.2.0(typescript@5.2.2)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.2.2
+      vitest:
+        specifier: ^0.34.0
+        version: 0.34.0(jsdom@27.4.0)
+
   packages/babylon-service:
     dependencies:
       '@babylonlabs-io/babylon-proto-ts':
@@ -1456,6 +1478,9 @@ importers:
       '@metamask/obs-store':
         specifier: ^7.0.0
         version: 7.0.0
+      '@noble/hashes':
+        specifier: ^1.3.0
+        version: 1.8.0
       '@unisat/wallet-bitcoin':
         specifier: workspace:*
         version: link:../wallet-bitcoin
@@ -1517,9 +1542,15 @@ importers:
 
   packages/notification-service:
     dependencies:
+      '@unisat/wallet-api':
+        specifier: workspace:*
+        version: link:../wallet-api
       '@unisat/wallet-shared':
         specifier: workspace:*
         version: link:../wallet-shared
+      '@unisat/wallet-storage':
+        specifier: workspace:*
+        version: link:../wallet-storage
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.1
@@ -1709,6 +1740,9 @@ importers:
 
   packages/wallet-background:
     dependencies:
+      '@unisat/approval-service':
+        specifier: workspace:*
+        version: link:../approval-service
       '@unisat/babylon-service':
         specifier: workspace:*
         version: link:../babylon-service
@@ -2271,7 +2305,7 @@ packages:
       '@babel/types': 7.28.4
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2402,7 +2436,7 @@ packages:
       '@babel/core': 7.20.2
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.1
+      debug: 4.4.3
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -2416,7 +2450,7 @@ packages:
       '@babel/core': 7.28.4
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.1
+      debug: 4.4.3
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -5057,7 +5091,7 @@ packages:
       '@babel/parser': 7.28.6
       '@babel/template': 7.27.2
       '@babel/types': 7.28.6
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5852,7 +5886,7 @@ packages:
       chalk: 4.1.2
       ci-info: 3.9.0
       connect: 3.7.0
-      debug: 4.4.1
+      debug: 4.4.3
       env-editor: 0.4.2
       fast-glob: 3.3.3
       find-yarn-workspace-root: 2.0.0
@@ -5924,7 +5958,7 @@ packages:
       '@expo/plist': 0.1.3
       '@expo/sdk-runtime-versions': 1.0.0
       chalk: 4.1.2
-      debug: 4.4.1
+      debug: 4.4.3
       find-up: 5.0.0
       getenv: 1.0.0
       glob: 7.1.6
@@ -5945,7 +5979,7 @@ packages:
       '@expo/plist': 0.1.3
       '@expo/sdk-runtime-versions': 1.0.0
       chalk: 4.1.2
-      debug: 4.4.1
+      debug: 4.4.3
       find-up: 5.0.0
       getenv: 1.0.0
       glob: 7.1.6
@@ -6010,7 +6044,7 @@ packages:
     resolution: {integrity: sha512-OtB9XVHWaXidLbHvrVDeeXa09yvTl3+IQN884sO6PhIi2/StXfgSH/9zC7IvzrDB8kW3EBJ1PPLuCUJ2hxAT7Q==}
     dependencies:
       chalk: 4.1.2
-      debug: 4.4.1
+      debug: 4.4.3
       dotenv: 16.4.7
       dotenv-expand: 11.0.7
       getenv: 1.0.0
@@ -6104,7 +6138,7 @@ packages:
       '@expo/json-file': 8.3.3
       '@expo/spawn-async': 1.7.2
       chalk: 4.1.2
-      debug: 4.4.1
+      debug: 4.4.3
       find-yarn-workspace-root: 2.0.0
       fs-extra: 9.1.0
       getenv: 1.0.0
@@ -6154,7 +6188,7 @@ packages:
       '@expo/image-utils': 0.5.1
       '@expo/json-file': 8.3.3
       '@react-native/normalize-colors': 0.74.84
-      debug: 4.4.1
+      debug: 4.4.3
       expo-modules-autolinking: 1.11.0
       fs-extra: 9.1.0
       resolve-from: 5.0.0
@@ -6176,7 +6210,7 @@ packages:
       '@expo/image-utils': 0.5.1
       '@expo/json-file': 8.3.3
       '@react-native/normalize-colors': 0.74.85
-      debug: 4.4.1
+      debug: 4.4.3
       expo-modules-autolinking: 1.11.1
       fs-extra: 9.1.0
       resolve-from: 5.0.0
@@ -6683,12 +6717,14 @@ packages:
   /@isaacs/balanced-match@4.0.1:
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
+    dev: true
 
   /@isaacs/brace-expansion@5.0.0:
     resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
     engines: {node: 20 || >=22}
     dependencies:
       '@isaacs/balanced-match': 4.0.1
+    dev: true
 
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -6705,7 +6741,7 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
     dev: true
 
   /@isaacs/string-locale-compare@1.1.0:
@@ -7652,7 +7688,7 @@ packages:
       hosted-git-info: 9.0.2
       json-stringify-nice: 1.1.4
       lru-cache: 11.2.6
-      minimatch: 10.1.1
+      minimatch: 10.2.2
       nopt: 8.1.0
       npm-install-checks: 7.1.2
       npm-package-arg: 13.0.1
@@ -10422,7 +10458,7 @@ packages:
     resolution: {integrity: sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA==}
     deprecated: This is a stub types definition. minimatch provides its own type definitions, so you do not need this installed.
     dependencies:
-      minimatch: 10.0.3
+      minimatch: 10.2.2
     dev: false
 
   /@types/minimist@1.2.5:
@@ -10925,7 +10961,7 @@ packages:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.0.4)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.50.0
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -11008,7 +11044,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.2.2)
       '@typescript-eslint/utils': 6.7.0(eslint@8.50.0)(typescript@5.2.2)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.50.0
       ts-api-utils: 1.4.3(typescript@5.2.2)
       typescript: 5.2.2
@@ -11028,7 +11064,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.7.0(typescript@5.5.3)
       '@typescript-eslint/utils': 6.7.0(eslint@8.50.0)(typescript@5.5.3)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.50.0
       ts-api-utils: 1.4.3(typescript@5.5.3)
       typescript: 5.5.3
@@ -11048,7 +11084,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.0.4)
       '@typescript-eslint/utils': 7.18.0(eslint@8.50.0)(typescript@5.0.4)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.50.0
       ts-api-utils: 1.4.3(typescript@5.0.4)
       typescript: 5.0.4
@@ -11124,7 +11160,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.7.0
       '@typescript-eslint/visitor-keys': 6.7.0
-      debug: 4.4.1
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.2
@@ -11145,7 +11181,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.7.0
       '@typescript-eslint/visitor-keys': 6.7.0
-      debug: 4.4.1
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.2
@@ -11166,7 +11202,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -11788,7 +11824,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13047,7 +13083,6 @@ packages:
   /balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
-    dev: true
 
   /bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
@@ -13423,7 +13458,6 @@ packages:
     engines: {node: 18 || 20 || >=22}
     dependencies:
       balanced-match: 4.0.4
-    dev: true
 
   /braces@2.3.2(supports-color@6.0.0):
     resolution: {integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==}
@@ -13789,7 +13823,7 @@ packages:
       fs-minipass: 3.0.3
       glob: 10.4.5
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-collect: 2.0.1
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
@@ -13807,7 +13841,7 @@ packages:
       fs-minipass: 3.0.3
       glob: 13.0.6
       lru-cache: 11.2.6
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-collect: 2.0.1
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
@@ -15439,7 +15473,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-    dev: true
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -18131,7 +18164,7 @@ packages:
     resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   /fs-mkdirp-stream@1.0.0:
     resolution: {integrity: sha512-+vSd9frUnapVC2RZYfL3FCB2p3g4TBhaUmrsWlSudsGdnxIuUvBB2QM1VZeBtc49QFwrp+wQLrDs3+xxDgI5gQ==}
@@ -18445,12 +18478,13 @@ packages:
 
   /glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.5
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -19211,7 +19245,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -19222,7 +19256,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -19231,7 +19265,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -19286,7 +19320,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -19295,7 +19329,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -20214,7 +20248,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -22527,7 +22561,7 @@ packages:
       '@npmcli/agent': 4.0.0
       cacache: 20.0.3
       http-cache-semantics: 4.2.0
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-fetch: 4.0.1
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
@@ -23279,6 +23313,7 @@ packages:
     engines: {node: 20 || >=22}
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
+    dev: true
 
   /minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
@@ -23292,7 +23327,6 @@ packages:
     engines: {node: 18 || 20 || >=22}
     dependencies:
       brace-expansion: 5.0.3
-    dev: true
 
   /minimatch@3.0.4:
     resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
@@ -23354,7 +23388,7 @@ packages:
     resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   /minipass-fetch@4.0.1:
     resolution: {integrity: sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==}
@@ -23423,11 +23457,11 @@ packages:
   /minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+    dev: true
 
   /minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
-    dev: true
 
   /minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
@@ -23441,7 +23475,7 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
     dev: true
 
   /mitt@1.1.3:
@@ -24068,7 +24102,7 @@ packages:
       '@npmcli/redact': 3.2.2
       jsonparse: 1.3.1
       make-fetch-happen: 15.0.2
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-fetch: 4.0.1
       minizlib: 3.1.0
       npm-package-arg: 13.0.1
@@ -24675,7 +24709,7 @@ packages:
       '@npmcli/run-script': 10.0.3
       cacache: 20.0.3
       fs-minipass: 3.0.3
-      minipass: 7.1.2
+      minipass: 7.1.3
       npm-package-arg: 13.0.1
       npm-packlist: 10.0.3
       npm-pick-manifest: 10.0.0
@@ -24964,14 +24998,14 @@ packages:
     engines: {node: '>=16 || 14 >=14.18'}
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   /path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
     dependencies:
       lru-cache: 11.2.6
-      minipass: 7.1.2
+      minipass: 7.1.3
     dev: true
 
   /path-scurry@2.0.2:
@@ -25160,7 +25194,7 @@ packages:
     engines: {node: '>= 10.12'}
     dependencies:
       async: 3.2.6
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -29442,7 +29476,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -29615,7 +29649,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -29628,7 +29662,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -29682,14 +29716,14 @@ packages:
     resolution: {integrity: sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
     dev: false
 
   /ssri@12.0.0:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
     dev: true
 
   /ssri@13.0.1:
@@ -30445,7 +30479,7 @@ packages:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
-      minipass: 7.1.2
+      minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
     dev: true
@@ -31051,7 +31085,7 @@ packages:
       bundle-require: 4.2.1(esbuild@0.18.20)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.4.1
+      debug: 4.4.3
       esbuild: 0.18.20
       execa: 5.1.1
       globby: 11.1.0
@@ -31851,7 +31885,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1
+      debug: 4.4.3
       mlly: 1.7.4
       pathe: 1.1.2
       picocolors: 1.1.1


### PR DESCRIPTION
## Summary

- Add `deriveContextHash(context)` API — derives a deterministic 32-byte value from the wallet's key material and a hex-encoded context string using HKDF-SHA-256 (RFC 5869)
- Supports all keyring types: HD (mnemonic), HD (xpriv), and imported private keys
- Includes user approval dialog before derivation
- i18n support for EN, FR, JA, RU, zh_TW

## Derivation scheme

HKDF-SHA-256(ikm=keyMaterial, salt="unisat-derive-context-hash", info=context, length=32)

Where `keyMaterial` is the 64-byte BIP-39 seed (mnemonic wallets) or 32-byte private key (imported/xpriv wallets).

## Security

- HKDF is a formally proven KDF (Krawczyk, Crypto 2010; RFC 5869), used by TLS 1.3, Signal, and Ethereum EIP-2333
- Fixed salt provides domain separation from BIP-32 and other HMAC uses
- Revealing millions of outputs for different contexts does not leak the seed or private key
- All intermediate key material zeroed after use
- Requires user approval via popup before derivation

## Changes

- `packages/keyring-service/src/keyrings/derive-context-hash.ts` — core HKDF derivation + hex parsing
- `packages/keyring-service/src/keyrings/simple-keyring.ts` — `deriveContextHash` for imported keys
- `packages/keyring-service/src/keyrings/hd-keyring.ts` — `deriveContextHash` for mnemonic/xpriv
- `packages/wallet-background/` — wallet controller + provider controller + method list
- `apps/extension/` — page provider API, approval UI component, i18n strings
- `docs/api/derive-context-hash.md` — API documentation


<img width="951" height="740" alt="image" src="https://github.com/user-attachments/assets/40022528-83d4-47ac-b77f-8451ce7aa174" />

<img width="703" height="1021" alt="image" src="https://github.com/user-attachments/assets/a16774ff-2945-453e-99a4-cf9b3ea9fe67" />
