### PR TITLE
fix: use provider-neutral HKDF salt for deriveContextHash

### DIFF
--- a/docs/api/derive-context-hash.md
+++ b/docs/api/derive-context-hash.md
@@ -23,7 +23,7 @@ Derive a deterministic 32-byte value from the wallet's key material and an arbit
 **Derivation Scheme**
 
 ```
-HKDF-SHA-256(ikm=keyMaterial, salt="unisat-derive-context-hash", info=context, length=32)
+HKDF-SHA-256(ikm=keyMaterial, salt="derive-context-hash", info=context, length=32)
 ```
 
 Where `keyMaterial` is:
@@ -40,7 +40,7 @@ try {
   const context = "a1b2c3d4e5f6...";
   const hash = await window.unisat.deriveContextHash(context);
   console.log(hash);
-  // => "16fa55f8a70ecc973e6baa1ffd77cd1db7bf019d78de4310f0011cc201007c02"
+  // => "fb9046c540159d2a3f2ff36c79da7079b9f65b9e231dcc47eaf780e57122359b"
 } catch (e) {
   console.log(e);
 }
@@ -53,7 +53,7 @@ try {
 - HKDF is a formally proven extract-then-expand KDF (Krawczyk, Crypto 2010; RFC 5869).
 - The Extract step ensures even structured inputs (e.g., secp256k1 keys) produce a uniformly random pseudorandom key.
 - The Expand step is a PRF — revealing many outputs for different contexts does not leak the seed or private key.
-- The fixed salt `"unisat-derive-context-hash"` provides domain separation from BIP-32 and other HMAC uses.
+- The fixed salt `"derive-context-hash"` provides domain separation from BIP-32 and other HMAC uses.
 - All intermediate key material is zeroed after use within the wallet.
 - Used by TLS 1.3, Signal Protocol, and Ethereum EIP-2333 for similar key derivation purposes.
 

--- a/packages/keyring-service/src/keyrings/derive-context-hash.ts
+++ b/packages/keyring-service/src/keyrings/derive-context-hash.ts
@@ -8,7 +8,7 @@
  * ## Derivation scheme
  *
  * ```
- * HKDF-SHA-256(ikm=keyMaterial, salt="unisat-derive-context-hash", info=context, length=32)
+ * HKDF-SHA-256(ikm=keyMaterial, salt="derive-context-hash", info=context, length=32)
  * ```
  *
  * Where `keyMaterial` is either the full 64-byte BIP-39 seed or a 32-byte
@@ -32,7 +32,7 @@
 import { hkdf } from '@noble/hashes/hkdf'
 import { sha256 } from '@noble/hashes/sha256'
 
-const SALT = 'unisat-derive-context-hash'
+const SALT = 'derive-context-hash'
 const OUTPUT_LENGTH = 32
 
 /**

--- a/packages/keyring-service/test/derive-context-hash.test.ts
+++ b/packages/keyring-service/test/derive-context-hash.test.ts
@@ -139,21 +139,21 @@ describe('deriveContextHash', () => {
       const ctx = Buffer.from('babylon-vault-test', 'utf-8')
       const result = deriveContextHash(freshSeed(), ctx)
       // Pinned value — if this changes, the derivation scheme has changed
-      expect(result).toBe('16fa55f8a70ecc973e6baa1ffd77cd1db7bf019d78de4310f0011cc201007c02')
+      expect(result).toBe('fb9046c540159d2a3f2ff36c79da7079b9f65b9e231dcc47eaf780e57122359b')
     })
 
     it('produces a stable output for a second context', () => {
       const ctx = Buffer.from('babylon-htlc-preimage', 'utf-8')
       const result = deriveContextHash(freshSeed(), ctx)
       // Second pinned value for broader regression coverage
-      expect(result).toBe('471e93f5b1964fde6cde9e83e8277f2268654a9a4178c775f8bf2912843e92ac')
+      expect(result).toBe('31cf9bf4e4311b944414deac608a908ec85dd82b240bea0d5a362f24ff49dc62')
     })
 
     it('produces a stable output for 32-byte private key', () => {
       const privKey = Buffer.from('69f477943dd1591f0261cabade0839e2ffc0c13d8fa1ce0d69f6c6c251163b34', 'hex')
       const ctx = Buffer.from('deadbeef', 'hex')
       const result = deriveContextHash(new Uint8Array(privKey), ctx)
-      expect(result).toBe('98263601b05e6d8e71e901d4f96ec4a23634ef17a7f26ee2f6dae3634f5f62c1')
+      expect(result).toBe('b86b70d096cbb96f290ad04b45734a4fdd232ab846c1d675802150065856fb30')
     })
   })
 })

--- a/packages/keyring-service/test/simple-keyring.test.ts
+++ b/packages/keyring-service/test/simple-keyring.test.ts
@@ -380,7 +380,7 @@ describe('bitcoin-simple-keyring', () => {
     it('known-answer test', async () => {
       const newKeyring = new SimpleKeyring([testAccount.key])
       const result = await newKeyring.deriveContextHash(testAccount.address, 'deadbeef')
-      expect(result).toBe('8f2064889f825ec2797ed764668b36998eebe22e682255b425edda0c2f6ed7f9')
+      expect(result).toBe('c75cfa090d2681fdde35ebd22330f0476221fb6d2edd9d9afc2953cab0bd1ce2')
     })
 
     it('different accounts produce different results', async () => {


### PR DESCRIPTION
## Summary

- Change the HKDF salt from `"unisat-derive-context-hash"` to `"derive-context-hash"` so all wallet providers (UniSat,
OKX, etc.) derive identical outputs for the same key material and context
- Update known-answer test vectors and API doc example to match the new salt

## Context

We're asking other wallet teams to implement the same `deriveContextHash` spec. A provider-neutral salt ensures interoperability — any wallet implementing the spec produces the same deterministic output.