### PR TITLE
feat: conform deriveContextHash to v1.0 spec (appName, BIP-32 IKM, st…

### DIFF
--- a/apps/extension/src/_locales/en/messages.json
+++ b/apps/extension/src/_locales/en/messages.json
@@ -1997,6 +1997,9 @@
   "derive_context_hash_description": {
     "message": "This site is requesting a unique identifier tied to your wallet for the following context."
   },
+  "derive_context_hash_app_name": {
+    "message": "Application"
+  },
   "derive_context_hash_context": {
     "message": "Context"
   },

--- a/apps/extension/src/_locales/fr/messages.json
+++ b/apps/extension/src/_locales/fr/messages.json
@@ -1973,6 +1973,9 @@
   "derive_context_hash_description": {
     "message": "Ce site demande un identifiant unique lié à votre portefeuille pour le contexte suivant."
   },
+  "derive_context_hash_app_name": {
+    "message": "Application"
+  },
   "derive_context_hash_context": {
     "message": "Contexte"
   },

--- a/apps/extension/src/_locales/ja/messages.json
+++ b/apps/extension/src/_locales/ja/messages.json
@@ -1973,6 +1973,9 @@
   "derive_context_hash_description": {
     "message": "このサイトは、以下のコンテキストに対してウォレットに紐づく一意の識別子を要求しています。"
   },
+  "derive_context_hash_app_name": {
+    "message": "Application"
+  },
   "derive_context_hash_context": {
     "message": "コンテキスト"
   },

--- a/apps/extension/src/_locales/ru/messages.json
+++ b/apps/extension/src/_locales/ru/messages.json
@@ -1973,6 +1973,9 @@
   "derive_context_hash_description": {
     "message": "Этот сайт запрашивает уникальный идентификатор, привязанный к вашему кошельку, для следующего контекста."
   },
+  "derive_context_hash_app_name": {
+    "message": "Application"
+  },
   "derive_context_hash_context": {
     "message": "Контекст"
   },

--- a/apps/extension/src/_locales/zh_TW/messages.json
+++ b/apps/extension/src/_locales/zh_TW/messages.json
@@ -1976,6 +1976,9 @@
   "derive_context_hash_description": {
     "message": "此網站正在請求一個與您的錢包綁定的唯一識別碼，用於以下上下文。"
   },
+  "derive_context_hash_app_name": {
+    "message": "Application"
+  },
   "derive_context_hash_context": {
     "message": "上下文"
   },

--- a/apps/extension/src/content-script/pageProvider/bitcoinAPI.ts
+++ b/apps/extension/src/content-script/pageProvider/bitcoinAPI.ts
@@ -250,8 +250,9 @@ export class BitcoinAPIMethods {
     });
   };
 
-  deriveContextHash = async (context: string) => {
+  deriveContextHash = async (appName: string, context: string) => {
     const params: RequestMethodDeriveContextHashParams = {
+      appName,
       context
     };
     return this.provider[requestMethodKey]({

--- a/apps/extension/src/content-script/pageProvider/index.ts
+++ b/apps/extension/src/content-script/pageProvider/index.ts
@@ -83,7 +83,7 @@ export class UnisatProvider extends EventEmitter {
   pushPsbt = async (psbtHex: string) => this.bitcoinAPI.pushPsbt(psbtHex);
   inscribeTransfer = async (ticker: string, amount: string) => this.bitcoinAPI.inscribeTransfer(ticker, amount);
   getVersion = async () => this.bitcoinAPI.getVersion();
-  deriveContextHash = async (context: string) => this.bitcoinAPI.deriveContextHash(context);
+  deriveContextHash = async (appName: string, context: string) => this.bitcoinAPI.deriveContextHash(appName, context);
   getBitcoinUtxos = async (cursor = 0, size = 20) => this.bitcoinAPI.getBitcoinUtxos(cursor, size);
 }
 

--- a/apps/extension/src/ui/pages/Approval/components/DeriveContextHash.tsx
+++ b/apps/extension/src/ui/pages/Approval/components/DeriveContextHash.tsx
@@ -15,6 +15,7 @@ import { useApproval, useI18n } from '@unisat/wallet-state';
 interface Props {
   params: {
     data: {
+      appName: string;
       context: string;
     };
     session: {
@@ -48,6 +49,11 @@ export default function DeriveContextHash({ params: { data, session } }: Props) 
           <Text text={t('derive_context_hash_request')} preset="title-bold" textCenter mt="lg" />
 
           <Text text={t('derive_context_hash_description')} textCenter mt="lg" />
+
+          <Text text={t('derive_context_hash_app_name')} preset="bold" mt="lg" />
+          <Card>
+            <Text text={data.appName} style={{ fontFamily: 'monospace', wordBreak: 'break-all' }} />
+          </Card>
 
           <Text text={t('derive_context_hash_context')} preset="bold" mt="lg" />
           <Card>

--- a/docs/api/derive-context-hash.md
+++ b/docs/api/derive-context-hash.md
@@ -3,32 +3,38 @@
 ### deriveContextHash
 
 ```
-unisat.deriveContextHash(context)
+unisat.deriveContextHash(appName, context)
 ```
 
-Derive a deterministic 32-byte value from the wallet's key material and an arbitrary context string. The derivation uses HKDF-SHA-256 (RFC 5869), a formally proven key derivation function.
+Derive a deterministic 32-byte value from the wallet's key material, an application name, and an arbitrary context string. The derivation uses HKDF-SHA-256 (RFC 5869).
 
-**Requires user approval** — the wallet will show a confirmation dialog displaying the context string before deriving the value.
+**Requires user approval** — the wallet will show a confirmation dialog displaying the application name, context string, and requesting origin before deriving the value.
 
 **Supported keyring types**: HD wallets (mnemonic), HD wallets (xpriv), and imported private keys.
 
 **Parameters**
 
-- `context` - `string`: A hex-encoded context string (even-length, e.g. `"deadbeef0123"`). The context acts as a domain separator — different contexts produce different, independent outputs.
+- `appName` - `string`: Application identifier (1–64 bytes, lowercase letters, digits, and hyphens only: `[a-z0-9\-]`). Provides mandatory app-level domain separation. Examples: `"babylon-vault"`, `"ordinals-market"`.
+- `context` - `string`: Hex-encoded byte string (even-length, lowercase, no `0x` prefix, max 2048 hex characters / 1024 bytes). Application-specific data that determines the output within the app's namespace. Must not be empty.
 
 **Returns**
 
-- `Promise` - `string`: Hex-encoded 32-byte derived value (64 hex characters).
+- `Promise` - `string`: Hex-encoded 32-byte derived value (64 lowercase hex characters).
 
 **Derivation Scheme**
 
 ```
-HKDF-SHA-256(ikm=keyMaterial, salt="derive-context-hash", info=context, length=32)
+ikm    = BIP-32 private key at m/73681862' (32 bytes)
+salt   = "derive-context-hash"
+info   = SHA-256(UTF8(appName)) || decode_hex(context)
+output = HKDF-SHA-256(ikm, salt, info, 32)
 ```
 
-Where `keyMaterial` is:
-- The 64-byte BIP-39 seed (for mnemonic-based wallets), or
-- The 32-byte private key (for imported key or xpriv wallets).
+Where `ikm` is:
+- For mnemonic/xpriv wallets: the 32-byte private key scalar at BIP-32 path `m/73681862'` (hardened), derived from the wallet's HD root.
+- For imported key wallets: the raw 32-byte private key directly (no BIP-32 derivation, since imported keys lack a BIP-32 hierarchy).
+
+The `info` field is constructed by concatenating SHA-256(UTF8(appName)) (32 bytes, fixed-length) with the raw context bytes decoded from hex. Hashing appName ensures a fixed 32-byte prefix, eliminating length-confusion collisions.
 
 ---
 
@@ -36,11 +42,11 @@ Where `keyMaterial` is:
 
 ```javascript
 try {
-  // Context is a hex-encoded string (e.g., vault_id + public_key)
-  const context = "a1b2c3d4e5f6...";
-  const hash = await window.unisat.deriveContextHash(context);
+  const appName = "babylon-vault";
+  const context = "a1b2c3d4e5f6..."; // hex-encoded context
+  const hash = await window.unisat.deriveContextHash(appName, context);
   console.log(hash);
-  // => "fb9046c540159d2a3f2ff36c79da7079b9f65b9e231dcc47eaf780e57122359b"
+  // => "3b0e2d90a01122eed8a520648073892f6b2d8f4419216023d63cdbd49500fca3"
 } catch (e) {
   console.log(e);
 }
@@ -54,8 +60,8 @@ try {
 - The Extract step ensures even structured inputs (e.g., secp256k1 keys) produce a uniformly random pseudorandom key.
 - The Expand step is a PRF — revealing many outputs for different contexts does not leak the seed or private key.
 - The fixed salt `"derive-context-hash"` provides domain separation from BIP-32 and other HMAC uses.
+- SHA-256(appName) prefix in the info field provides mandatory app-level domain separation.
 - All intermediate key material is zeroed after use within the wallet.
-- Used by TLS 1.3, Signal Protocol, and Ethereum EIP-2333 for similar key derivation purposes.
 
 **Use Cases**
 

--- a/packages/keyring-service/README.md
+++ b/packages/keyring-service/README.md
@@ -135,7 +135,7 @@ Main service class for managing keyrings.
 
 ##### Key Derivation
 
-- `deriveContextHash(publicKey: string, context: string): Promise<string>` - Derive a deterministic 32-byte value from the wallet's key material and a hex-encoded context string using HKDF-SHA-256 (RFC 5869). Supported by all keyring types: HD (mnemonic), HD (xpriv), and imported private keys.
+- `deriveContextHash(publicKey: string, appName: string, context: string): Promise<string>` - Derive a deterministic 32-byte value from the wallet's key material, an application name, and a hex-encoded context string using HKDF-SHA-256 (RFC 5869). The `appName` must be 1-64 bytes, lowercase `[a-z0-9\-]`. Supported by all keyring types: HD (mnemonic), HD (xpriv), and imported private keys.
 
 ### Types
 

--- a/packages/keyring-service/src/keyrings/derive-context-hash.ts
+++ b/packages/keyring-service/src/keyrings/derive-context-hash.ts
@@ -1,30 +1,14 @@
 /**
  * Deterministic context-based key derivation using HKDF (RFC 5869).
  *
- * Derives a 32-byte pseudorandom value from either:
- * - A 64-byte BIP-39 seed (mnemonic-based keyrings), or
- * - A 32-byte private key (imported key keyrings), expanded via HKDF first.
- *
- * ## Derivation scheme
+ * ## Derivation scheme (spec v1.0, algorithm version 0)
  *
  * ```
- * HKDF-SHA-256(ikm=keyMaterial, salt="derive-context-hash", info=context, length=32)
+ * ikm    = 32-byte private key (BIP-32 derived at m/73681862' or raw imported key)
+ * salt   = "derive-context-hash"
+ * info   = SHA-256(UTF8(appName)) || contextBytes
+ * output = HKDF-SHA-256(ikm, salt, info, 32)
  * ```
- *
- * Where `keyMaterial` is either the full 64-byte BIP-39 seed or a 32-byte
- * private key. HKDF-Extract produces a pseudorandom key (PRK) from the input,
- * and HKDF-Expand derives the output keyed on the context.
- *
- * ## Security
- *
- * - HKDF is a formally proven extract-then-expand KDF (Krawczyk, Crypto 2010).
- * - The Extract step ensures that even structured input (e.g. secp256k1 keys
- *   constrained to < curve order) produces a uniformly random PRK.
- * - The Expand step is a PRF; revealing outputs for many different contexts
- *   does not leak the PRK, seed, or any BIP-32 private keys.
- * - A fixed salt provides domain separation from BIP-32 and other HMAC uses.
- * - All intermediate key material is zeroed after use.
- * - Safe to reveal up to 2^256 outputs (birthday bound of HMAC-SHA-256).
  *
  * @module derive-context-hash
  */
@@ -45,39 +29,73 @@ function toHex(bytes: Uint8Array): string {
 }
 
 /**
- * Derive a deterministic 32-byte value from key material and a context.
+ * Derive a deterministic 32-byte value from key material, app name, and context.
  *
- * @param ikm     - Input key material: 64-byte BIP-39 seed or 32-byte private key.
- * @param context - Arbitrary context bytes (caller-defined domain separator).
+ * @param ikm     - Input key material: 32-byte private key.
+ * @param appName - Application identifier (1-64 bytes, [a-z0-9\-]).
+ * @param context - Context bytes decoded from hex.
  * @returns Hex-encoded 32-byte derived value.
  */
-export function deriveContextHash(ikm: Uint8Array, context: Uint8Array): string {
-  if (ikm.length !== 64 && ikm.length !== 32) {
-    throw new Error(`Input key material must be 32 or 64 bytes, got ${ikm.length}`)
+export function deriveContextHash(ikm: Uint8Array, appName: string, context: Uint8Array): string {
+  if (ikm.length !== 32) {
+    throw new Error(`Input key material must be 32 bytes, got ${ikm.length}`)
   }
 
-  const derived = hkdf(sha256, ikm, SALT, context, OUTPUT_LENGTH)
+  validateAppName(appName)
+
+  // info = SHA-256(UTF8(appName)) || contextBytes
+  const appNameHash = sha256(new TextEncoder().encode(appName))
+  const info = new Uint8Array(appNameHash.length + context.length)
+  info.set(appNameHash, 0)
+  info.set(context, appNameHash.length)
+
+  const derived = hkdf(sha256, ikm, SALT, info, OUTPUT_LENGTH)
   const result = toHex(derived)
 
   // Zero intermediate material
   derived.fill(0)
+  info.fill(0)
 
   return result
 }
 
 /**
+ * Validate the appName parameter per spec.
+ * Must be 1-64 bytes, ASCII lowercase letters, digits, and hyphens only.
+ */
+export function validateAppName(appName: string): void {
+  if (typeof appName !== 'string' || appName.length === 0) {
+    throw new Error('appName must be a non-empty string')
+  }
+  const bytes = new TextEncoder().encode(appName)
+  if (bytes.length > 64) {
+    throw new Error(`appName must be at most 64 bytes, got ${bytes.length}`)
+  }
+  if (!/^[a-z0-9\-]+$/.test(appName)) {
+    throw new Error('appName must contain only lowercase letters, digits, and hyphens')
+  }
+}
+
+/**
  * Parse a hex-encoded context string into a Uint8Array.
- * Validates that the input is a non-empty, even-length hex string.
+ * Validates per spec: non-empty, even-length, lowercase hex only,
+ * no 0x prefix, max 2048 hex characters (1024 bytes).
  */
 export function parseHexContext(context: string): Uint8Array {
-  if (!context || context.length === 0) {
+  if (typeof context !== 'string' || context.length === 0) {
     throw new Error('Context must be a non-empty string')
+  }
+  if (context.startsWith('0x') || context.startsWith('0X')) {
+    throw new Error('Context must not have a 0x prefix')
   }
   if (context.length % 2 !== 0) {
     throw new Error('Context must be an even-length hex string')
   }
-  if (!/^[0-9a-fA-F]+$/.test(context)) {
-    throw new Error('Context must be a valid hex string')
+  if (context.length > 2048) {
+    throw new Error('Context must not exceed 2048 hex characters (1024 bytes)')
+  }
+  if (!/^[0-9a-f]+$/.test(context)) {
+    throw new Error('Context must be a lowercase hex string')
   }
   const bytes = new Uint8Array(context.length / 2)
   for (let i = 0; i < bytes.length; i++) {

--- a/packages/keyring-service/src/keyrings/hd-keyring.ts
+++ b/packages/keyring-service/src/keyrings/hd-keyring.ts
@@ -9,6 +9,8 @@ import { deriveContextHash, parseHexContext } from './derive-context-hash'
 import { SimpleKeyring } from './simple-keyring'
 
 const hdPathString = "m/44'/0'/0'/0"
+// BIP-32 path for deriveContextHash IKM. Purpose index = trunc31_be(SHA-256("derive-context-hash")).
+const DERIVE_CONTEXT_HASH_PATH = "m/73681862'"
 const type = 'HD Key Tree'
 
 interface DeserializeOption {
@@ -264,35 +266,28 @@ export class HdKeyring extends SimpleKeyring {
 
   /**
    * Derive a deterministic context hash from the wallet's key material.
-   * Uses the 64-byte BIP-39 seed for mnemonic keyrings, or the xpriv
-   * root private key (32 bytes) for xpriv-only keyrings.
+   * Uses BIP-32 derivation at m/73681862' from the HD wallet root.
    *
-   * @param publicKey - Public key identifying the account (unused for HD keyrings
-   *   since derivation is from the root, but kept for interface consistency).
+   * @param _publicKey - Unused for HD keyrings (derivation is from root).
+   * @param appName - Application identifier.
    * @param context - Hex-encoded context string.
-   * @returns Hex-encoded 32-byte derived value (64 hex characters).
    */
-  override async deriveContextHash(_publicKey: string, context: string): Promise<string> {
+  override async deriveContextHash(_publicKey: string, appName: string, context: string): Promise<string> {
     const contextBytes = parseHexContext(context)
-    if (this.mnemonic) {
-      const seedBuf = bip39.mnemonicToSeedSync(this.mnemonic, this.passphrase)
-      const seed = new Uint8Array(seedBuf.buffer, seedBuf.byteOffset, seedBuf.byteLength)
-      try {
-        return deriveContextHash(seed, contextBytes)
-      } finally {
-        seed.fill(0)
+    if (!this.hdWallet) {
+      throw new Error('deriveContextHash requires a mnemonic or xpriv-based keyring')
+    }
+    const child = this.hdWallet.derive(DERIVE_CONTEXT_HASH_PATH)
+    const privKeyBytes = new Uint8Array(child.privateKey)
+    try {
+      return deriveContextHash(privKeyBytes, appName, contextBytes)
+    } finally {
+      privKeyBytes.fill(0)
+      // Zero the original BIP-32 node's key buffer as well
+      if (child.privateKey) {
+        child.privateKey.fill(0)
       }
     }
-    // xpriv-only: use the root xpriv private key
-    if (this.root && this.root.privateKey) {
-      const privKeyBytes = new Uint8Array(this.root.privateKey)
-      try {
-        return deriveContextHash(privKeyBytes, contextBytes)
-      } finally {
-        privKeyBytes.fill(0)
-      }
-    }
-    throw new Error('deriveContextHash requires a mnemonic or xpriv-based keyring')
   }
 
   private _addressFromIndex(i: number) {

--- a/packages/keyring-service/src/keyrings/simple-keyring.ts
+++ b/packages/keyring-service/src/keyrings/simple-keyring.ts
@@ -128,7 +128,7 @@ export class SimpleKeyring extends EventEmitter {
     this.wallets = this.wallets.filter(wallet => wallet.publicKey.toString('hex') !== publicKey)
   }
 
-  async deriveContextHash(publicKey: string, context: string): Promise<string> {
+  async deriveContextHash(publicKey: string, appName: string, context: string): Promise<string> {
     const wallet = this._getWalletForAccount(publicKey)
     if (!wallet.privateKey) {
       throw new Error('deriveContextHash requires access to the private key')
@@ -136,7 +136,7 @@ export class SimpleKeyring extends EventEmitter {
     const contextBytes = parseHexContext(context)
     const privKeyBytes = new Uint8Array(wallet.privateKey)
     try {
-      return deriveContextHash(privKeyBytes, contextBytes)
+      return deriveContextHash(privKeyBytes, appName, contextBytes)
     } finally {
       privKeyBytes.fill(0)
     }

--- a/packages/keyring-service/src/types/keyring.ts
+++ b/packages/keyring-service/src/types/keyring.ts
@@ -39,7 +39,7 @@ export interface Keyring {
 
   changeHdPath?(hdPath: string): void
   getAccountByHdPath?(hdPath: string, index: number): string
-  deriveContextHash?(publicKey: string, context: string): Promise<string>
+  deriveContextHash?(publicKey: string, appName: string, context: string): Promise<string>
 
   // Keystone specific methods
   genSignPsbtUr?(psbtHex: string): Promise<{ type: string; cbor: string }>

--- a/packages/keyring-service/test/derive-context-hash.test.ts
+++ b/packages/keyring-service/test/derive-context-hash.test.ts
@@ -1,181 +1,138 @@
-import * as bip39 from 'bip39'
 import { describe, expect, it } from 'vitest'
 
-import { deriveContextHash, parseHexContext } from '../src/keyrings/derive-context-hash'
-
-const KNOWN_MNEMONIC =
-  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
-
-const SAMPLE_MNEMONIC =
-  'finish oppose decorate face calm tragic certain desk hour urge dinosaur mango'
-
-function freshSeed(): Uint8Array {
-  const seed = bip39.mnemonicToSeedSync(KNOWN_MNEMONIC)
-  return new Uint8Array(seed.buffer, seed.byteOffset, seed.byteLength)
-}
+import { deriveContextHash, parseHexContext, validateAppName } from '../src/keyrings/derive-context-hash'
 
 describe('deriveContextHash', () => {
-  describe('output format', () => {
-    it('returns a 64-character hex string (32 bytes) for 64-byte seed', () => {
-      const ctx = Buffer.from('test-context', 'utf-8')
-      const result = deriveContextHash(freshSeed(), ctx)
-      expect(result).toHaveLength(64)
-      expect(result).toMatch(/^[0-9a-f]{64}$/)
-    })
+  const APP_NAME = 'test-app'
 
-    it('returns a 64-character hex string (32 bytes) for 32-byte key', () => {
-      const ctx = Buffer.from('test-context', 'utf-8')
+  describe('output format', () => {
+    it('returns a 64-character hex string (32 bytes)', () => {
+      const ctx = parseHexContext('deadbeef')
       const key = new Uint8Array(32).fill(0xab)
-      const result = deriveContextHash(key, ctx)
+      const result = deriveContextHash(key, APP_NAME, ctx)
       expect(result).toHaveLength(64)
       expect(result).toMatch(/^[0-9a-f]{64}$/)
     })
   })
 
   describe('determinism', () => {
-    it('produces identical results for same seed + context', () => {
-      const ctx = Buffer.from('test-context', 'utf-8')
-      const a = deriveContextHash(freshSeed(), ctx)
-      const b = deriveContextHash(freshSeed(), ctx)
-      expect(a).toBe(b)
-    })
-
-    it('produces identical results for same 32-byte key + context', () => {
-      const ctx = Buffer.from('test-context', 'utf-8')
+    it('produces identical results for same key + appName + context', () => {
+      const ctx = parseHexContext('deadbeef')
       const key = new Uint8Array(32).fill(0xab)
-      const a = deriveContextHash(key, ctx)
-      const b = deriveContextHash(key, ctx)
+      const a = deriveContextHash(key, APP_NAME, ctx)
+      const b = deriveContextHash(key, APP_NAME, ctx)
       expect(a).toBe(b)
     })
   })
 
   describe('context differentiation', () => {
     it('produces different results for different contexts', () => {
-      const ctx1 = Buffer.from('context-1', 'utf-8')
-      const ctx2 = Buffer.from('context-2', 'utf-8')
-      const a = deriveContextHash(freshSeed(), ctx1)
-      const b = deriveContextHash(freshSeed(), ctx2)
+      const key = new Uint8Array(32).fill(0xab)
+      const a = deriveContextHash(key, APP_NAME, parseHexContext('01'))
+      const b = deriveContextHash(key, APP_NAME, parseHexContext('02'))
       expect(a).not.toBe(b)
     })
 
-    it('produces different results for empty vs non-empty context', () => {
-      const empty = new Uint8Array(0)
-      const nonempty = Buffer.from('x', 'utf-8')
-      const a = deriveContextHash(freshSeed(), empty)
-      const b = deriveContextHash(freshSeed(), nonempty)
+    it('produces different results for different appNames', () => {
+      const key = new Uint8Array(32).fill(0xab)
+      const ctx = parseHexContext('deadbeef')
+      const a = deriveContextHash(key, 'app-one', ctx)
+      const b = deriveContextHash(key, 'app-two', ctx)
       expect(a).not.toBe(b)
     })
   })
 
   describe('input validation', () => {
-    it('rejects key material that is not 32 or 64 bytes', () => {
-      const ctx = Buffer.from('test', 'utf-8')
-      expect(() => deriveContextHash(new Uint8Array(16), ctx)).toThrow(
-        'Input key material must be 32 or 64 bytes, got 16'
+    it('rejects key material that is not 32 bytes', () => {
+      const ctx = parseHexContext('deadbeef')
+      expect(() => deriveContextHash(new Uint8Array(16), APP_NAME, ctx)).toThrow(
+        'Input key material must be 32 bytes, got 16'
       )
-      expect(() => deriveContextHash(new Uint8Array(48), ctx)).toThrow(
-        'Input key material must be 32 or 64 bytes, got 48'
-      )
-      expect(() => deriveContextHash(new Uint8Array(128), ctx)).toThrow(
-        'Input key material must be 32 or 64 bytes, got 128'
+      expect(() => deriveContextHash(new Uint8Array(64), APP_NAME, ctx)).toThrow(
+        'Input key material must be 32 bytes, got 64'
       )
     })
-  })
 
-  describe('seed vs private key isolation', () => {
-    it('32-byte key and 64-byte seed produce different results for same context', () => {
-      const ctx = Buffer.from('test-context', 'utf-8')
-      const seed = freshSeed()
-      const key32 = seed.slice(0, 32) // first 32 bytes of seed
-      const a = deriveContextHash(seed, ctx)
-      const b = deriveContextHash(key32, ctx)
-      expect(a).not.toBe(b)
+    it('rejects invalid appName', () => {
+      const key = new Uint8Array(32).fill(0xab)
+      const ctx = parseHexContext('deadbeef')
+      expect(() => deriveContextHash(key, '', ctx)).toThrow('non-empty string')
+      expect(() => deriveContextHash(key, 'UPPER', ctx)).toThrow('lowercase')
+      expect(() => deriveContextHash(key, 'has space', ctx)).toThrow('lowercase')
     })
   })
 
-  describe('binary context edge cases', () => {
-    it('handles all-zero context', () => {
-      const ctx = new Uint8Array(32)
-      const result = deriveContextHash(freshSeed(), ctx)
-      expect(result).toHaveLength(64)
-      expect(result).toMatch(/^[0-9a-f]{64}$/)
+  describe('known-answer tests (spec vectors)', () => {
+    // Spec test vectors use BIP-39 mnemonic "abandon...about" (no passphrase)
+    // IKM = BIP-32 private key at m/73681862'
+    const IKM_HEX = '391cdb922097ec9c96fc13cadb01d5745ccf31f5dbec3a38103440714779ec85'
+    const ikm = new Uint8Array(Buffer.from(IKM_HEX, 'hex'))
+
+    it('vector 1: context=deadbeef', () => {
+      const result = deriveContextHash(ikm, 'test-app', parseHexContext('deadbeef'))
+      expect(result).toBe('3b0e2d90a01122eed8a520648073892f6b2d8f4419216023d63cdbd49500fca3')
     })
 
-    it('handles all-0xff context', () => {
-      const ctx = new Uint8Array(32).fill(0xff)
-      const result = deriveContextHash(freshSeed(), ctx)
-      expect(result).toHaveLength(64)
-      expect(result).toMatch(/^[0-9a-f]{64}$/)
+    it('vector 2: context=00', () => {
+      const result = deriveContextHash(ikm, 'test-app', parseHexContext('00'))
+      expect(result).toBe('50775126782c1a5e4d60daa4666b2c7590f0b5a445a4115b0abd411467c92597')
     })
 
-    it('handles large context (10KB)', () => {
-      const ctx = new Uint8Array(10240).fill(0xab)
-      const result = deriveContextHash(freshSeed(), ctx)
-      expect(result).toHaveLength(64)
-      expect(result).toMatch(/^[0-9a-f]{64}$/)
-    })
-
-    it('all-zero and all-0xff contexts produce different results', () => {
-      const zeros = deriveContextHash(freshSeed(), new Uint8Array(32))
-      const ones = deriveContextHash(freshSeed(), new Uint8Array(32).fill(0xff))
-      expect(zeros).not.toBe(ones)
-    })
-  })
-
-  describe('different mnemonics', () => {
-    it('produces different results for different seeds with same context', () => {
-      const ctx = Buffer.from('test-context', 'utf-8')
-      const seed1 = freshSeed()
-      const seed2Buf = bip39.mnemonicToSeedSync(SAMPLE_MNEMONIC)
-      const seed2 = new Uint8Array(seed2Buf.buffer, seed2Buf.byteOffset, seed2Buf.byteLength)
-      const a = deriveContextHash(seed1, ctx)
-      const b = deriveContextHash(seed2, ctx)
-      expect(a).not.toBe(b)
-    })
-  })
-
-  describe('known-answer tests (HKDF-SHA-256)', () => {
-    it('produces a stable output for regression detection', () => {
-      const ctx = Buffer.from('babylon-vault-test', 'utf-8')
-      const result = deriveContextHash(freshSeed(), ctx)
-      // Pinned value — if this changes, the derivation scheme has changed
-      expect(result).toBe('fb9046c540159d2a3f2ff36c79da7079b9f65b9e231dcc47eaf780e57122359b')
-    })
-
-    it('produces a stable output for a second context', () => {
-      const ctx = Buffer.from('babylon-htlc-preimage', 'utf-8')
-      const result = deriveContextHash(freshSeed(), ctx)
-      // Second pinned value for broader regression coverage
-      expect(result).toBe('31cf9bf4e4311b944414deac608a908ec85dd82b240bea0d5a362f24ff49dc62')
-    })
-
-    it('produces a stable output for 32-byte private key', () => {
-      const privKey = Buffer.from('69f477943dd1591f0261cabade0839e2ffc0c13d8fa1ce0d69f6c6c251163b34', 'hex')
-      const ctx = Buffer.from('deadbeef', 'hex')
-      const result = deriveContextHash(new Uint8Array(privKey), ctx)
-      expect(result).toBe('b86b70d096cbb96f290ad04b45734a4fdd232ab846c1d675802150065856fb30')
+    it('vector 3: context=64 zero bytes', () => {
+      const context128zeros = '00'.repeat(64) // 64 zero bytes = 128 hex chars
+      const result = deriveContextHash(ikm, 'test-app', parseHexContext(context128zeros))
+      expect(result).toBe('d81e4a91f32eabd34df0e55ca36f26f211af65dfe575b7201c95baaa6608cdd9')
     })
   })
 })
 
-// Note: HdKeyring integration tests are in hd-keyring.test.ts
-// because HdKeyring imports @unisat/wallet-bitcoin which requires the package to be built first.
-// SimpleKeyring integration tests are in simple-keyring.test.ts.
+describe('validateAppName', () => {
+  it('accepts valid appNames', () => {
+    expect(() => validateAppName('test-app')).not.toThrow()
+    expect(() => validateAppName('babylon-vault')).not.toThrow()
+    expect(() => validateAppName('a')).not.toThrow()
+    expect(() => validateAppName('a-b-c-123')).not.toThrow()
+  })
+
+  it('rejects empty', () => {
+    expect(() => validateAppName('')).toThrow('non-empty string')
+  })
+
+  it('rejects uppercase', () => {
+    expect(() => validateAppName('Test-App')).toThrow('lowercase')
+  })
+
+  it('rejects spaces', () => {
+    expect(() => validateAppName('test app')).toThrow('lowercase')
+  })
+
+  it('rejects underscores', () => {
+    expect(() => validateAppName('test_app')).toThrow('lowercase')
+  })
+
+  it('rejects > 64 bytes', () => {
+    const longName = 'a'.repeat(65)
+    expect(() => validateAppName(longName)).toThrow('64 bytes')
+  })
+
+  it('accepts exactly 64 bytes', () => {
+    const name64 = 'a'.repeat(64)
+    expect(() => validateAppName(name64)).not.toThrow()
+  })
+})
 
 describe('parseHexContext', () => {
-  it('parses valid hex string', () => {
+  it('parses valid lowercase hex string', () => {
     const result = parseHexContext('deadbeef')
     expect(result).toEqual(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))
   })
 
-  it('handles uppercase hex', () => {
-    const result = parseHexContext('DEADBEEF')
-    expect(result).toEqual(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))
+  it('rejects uppercase hex', () => {
+    expect(() => parseHexContext('DEADBEEF')).toThrow('lowercase')
   })
 
-  it('handles mixed case hex', () => {
-    const result = parseHexContext('DeAdBeEf')
-    expect(result).toEqual(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))
+  it('rejects mixed case hex', () => {
+    expect(() => parseHexContext('DeAdBeEf')).toThrow('lowercase')
   })
 
   it('rejects empty string', () => {
@@ -187,6 +144,24 @@ describe('parseHexContext', () => {
   })
 
   it('rejects non-hex characters', () => {
-    expect(() => parseHexContext('xyz123')).toThrow('valid hex')
+    expect(() => parseHexContext('xyz123')).toThrow('lowercase hex')
+  })
+
+  it('rejects 0x prefix', () => {
+    expect(() => parseHexContext('0xdeadbeef')).toThrow('0x prefix')
+  })
+
+  it('rejects 0X prefix', () => {
+    expect(() => parseHexContext('0Xdeadbeef')).toThrow('0x prefix')
+  })
+
+  it('rejects context exceeding 2048 hex chars', () => {
+    const longHex = 'ab'.repeat(1025) // 2050 hex chars
+    expect(() => parseHexContext(longHex)).toThrow('2048')
+  })
+
+  it('accepts context of exactly 2048 hex chars', () => {
+    const maxHex = 'ab'.repeat(1024) // 2048 hex chars
+    expect(() => parseHexContext(maxHex)).not.toThrow()
   })
 })

--- a/packages/keyring-service/test/hd-keyring.test.ts
+++ b/packages/keyring-service/test/hd-keyring.test.ts
@@ -286,30 +286,36 @@ describe('bitcoin-hd-keyring', () => {
   })
 
   describe('deriveContextHash', () => {
+    const APP_NAME = 'test-app'
+
     it('derives context hash with mnemonic-based keyring', async () => {
       const keyring = new HdKeyring({
         mnemonic: sampleMnemonic,
         activeIndexes: [0],
       })
       const accounts = await keyring.getAccounts()
-      const result = await keyring.deriveContextHash(accounts[0], 'deadbeef')
+      const result = await keyring.deriveContextHash(accounts[0], APP_NAME, 'deadbeef')
       expect(result).toHaveLength(64)
       expect(result).toMatch(/^[0-9a-f]{64}$/)
     })
 
-    it('produces same result as direct derivation', async () => {
+    it('produces same result as direct derivation with BIP-32 derived key', async () => {
       const keyring = new HdKeyring({
         mnemonic: sampleMnemonic,
         activeIndexes: [0],
       })
       const accounts = await keyring.getAccounts()
       const contextHex = 'deadbeef'
-      const keyringResult = await keyring.deriveContextHash(accounts[0], contextHex)
+      const keyringResult = await keyring.deriveContextHash(accounts[0], APP_NAME, contextHex)
 
+      // Manually derive BIP-32 key at m/73681862' and compute directly
       const bip39 = await import('bip39')
+      const hdkey = await import('hdkey')
       const seedBuf = bip39.mnemonicToSeedSync(sampleMnemonic)
-      const seed = new Uint8Array(seedBuf.buffer, seedBuf.byteOffset, seedBuf.byteLength)
-      const directResult = deriveContextHash(seed, parseHexContext(contextHex))
+      const master = hdkey.fromMasterSeed(seedBuf)
+      const child = master.derive("m/73681862'")
+      const privKey = new Uint8Array(child.privateKey)
+      const directResult = deriveContextHash(privKey, APP_NAME, parseHexContext(contextHex))
       expect(keyringResult).toBe(directResult)
     })
 
@@ -319,13 +325,12 @@ describe('bitcoin-hd-keyring', () => {
         activeIndexes: [0, 1],
       })
       const accounts = await keyring.getAccounts()
-      const result0 = await keyring.deriveContextHash(accounts[0], 'deadbeef')
-      const result1 = await keyring.deriveContextHash(accounts[1], 'deadbeef')
-      // HD keyring derives from the root seed, not individual account keys
+      const result0 = await keyring.deriveContextHash(accounts[0], APP_NAME, 'deadbeef')
+      const result1 = await keyring.deriveContextHash(accounts[1], APP_NAME, 'deadbeef')
       expect(result0).toBe(result1)
     })
 
-    it('xpriv-only keyring uses root private key', async () => {
+    it('xpriv-only keyring derives from BIP-32 path', async () => {
       const sampleXpriv =
         'xprvA2JBuYsdqVhrC2wGmb9QhBejk9gXXYgM3Jg9xgVYmDMsakDoURc8V7UYos1pP1kev1tG51PPA9A8VMYYCLov1L5c3J7npraxwjeJCquGhDi'
       const keyring = new HdKeyring({
@@ -333,27 +338,9 @@ describe('bitcoin-hd-keyring', () => {
         activeIndexes: [0],
       })
       const accounts = await keyring.getAccounts()
-      const result = await keyring.deriveContextHash(accounts[0], 'deadbeef')
+      const result = await keyring.deriveContextHash(accounts[0], APP_NAME, 'deadbeef')
       expect(result).toHaveLength(64)
       expect(result).toMatch(/^[0-9a-f]{64}$/)
-    })
-
-    it('mnemonic and xpriv produce different results for same context', async () => {
-      const sampleXpriv =
-        'xprvA2JBuYsdqVhrC2wGmb9QhBejk9gXXYgM3Jg9xgVYmDMsakDoURc8V7UYos1pP1kev1tG51PPA9A8VMYYCLov1L5c3J7npraxwjeJCquGhDi'
-      const mnemonicKeyring = new HdKeyring({
-        mnemonic: sampleMnemonic,
-        activeIndexes: [0],
-      })
-      const xprivKeyring = new HdKeyring({
-        xpriv: sampleXpriv,
-        activeIndexes: [0],
-      })
-      const mnemonicAccounts = await mnemonicKeyring.getAccounts()
-      const xprivAccounts = await xprivKeyring.getAccounts()
-      const mnemonicResult = await mnemonicKeyring.deriveContextHash(mnemonicAccounts[0], 'deadbeef')
-      const xprivResult = await xprivKeyring.deriveContextHash(xprivAccounts[0], 'deadbeef')
-      expect(mnemonicResult).not.toBe(xprivResult)
     })
 
     it('xpriv result is stable regardless of account activation order', async () => {
@@ -369,9 +356,8 @@ describe('bitcoin-hd-keyring', () => {
       })
       const accounts1 = await keyring1.getAccounts()
       const accounts2 = await keyring2.getAccounts()
-      const result1 = await keyring1.deriveContextHash(accounts1[0], 'deadbeef')
-      const result2 = await keyring2.deriveContextHash(accounts2[0], 'deadbeef')
-      // Both use root xpriv key, so results must match
+      const result1 = await keyring1.deriveContextHash(accounts1[0], APP_NAME, 'deadbeef')
+      const result2 = await keyring2.deriveContextHash(accounts2[0], APP_NAME, 'deadbeef')
       expect(result1).toBe(result2)
     })
 
@@ -381,16 +367,28 @@ describe('bitcoin-hd-keyring', () => {
         activeIndexes: [0],
       })
       const accounts = await keyring.getAccounts()
-      await expect(keyring.deriveContextHash(accounts[0], 'xyz')).rejects.toThrow()
-      await expect(keyring.deriveContextHash(accounts[0], '')).rejects.toThrow()
-      await expect(keyring.deriveContextHash(accounts[0], 'abc')).rejects.toThrow()
+      await expect(keyring.deriveContextHash(accounts[0], APP_NAME, 'xyz')).rejects.toThrow()
+      await expect(keyring.deriveContextHash(accounts[0], APP_NAME, '')).rejects.toThrow()
+      await expect(keyring.deriveContextHash(accounts[0], APP_NAME, 'abc')).rejects.toThrow()
     })
 
     it('rejects uninitialized keyring', async () => {
       const keyring = new HdKeyring()
-      await expect(keyring.deriveContextHash('anypubkey', 'deadbeef')).rejects.toThrow(
+      await expect(keyring.deriveContextHash('anypubkey', APP_NAME, 'deadbeef')).rejects.toThrow(
         'requires a mnemonic or xpriv-based keyring'
       )
+    })
+
+    it('spec vector 1 with known mnemonic', async () => {
+      const knownMnemonic =
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+      const keyring = new HdKeyring({
+        mnemonic: knownMnemonic,
+        activeIndexes: [0],
+      })
+      const accounts = await keyring.getAccounts()
+      const result = await keyring.deriveContextHash(accounts[0], 'test-app', 'deadbeef')
+      expect(result).toBe('3b0e2d90a01122eed8a520648073892f6b2d8f4419216023d63cdbd49500fca3')
     })
   })
 

--- a/packages/keyring-service/test/simple-keyring.test.ts
+++ b/packages/keyring-service/test/simple-keyring.test.ts
@@ -362,49 +362,52 @@ describe('bitcoin-simple-keyring', () => {
   })
 
   describe('#deriveContextHash', () => {
+    const APP_NAME = 'test-app'
+
     it('derives a 64-char hex value', async () => {
       const newKeyring = new SimpleKeyring([testAccount.key])
-      const result = await newKeyring.deriveContextHash(testAccount.address, 'deadbeef')
+      const result = await newKeyring.deriveContextHash(testAccount.address, APP_NAME, 'deadbeef')
       expect(result).toHaveLength(64)
       expect(result).toMatch(/^[0-9a-f]{64}$/)
     })
 
     it('produces same result as direct derivation', async () => {
       const newKeyring = new SimpleKeyring([testAccount.key])
-      const result = await newKeyring.deriveContextHash(testAccount.address, 'deadbeef')
+      const result = await newKeyring.deriveContextHash(testAccount.address, APP_NAME, 'deadbeef')
       const privKeyBytes = new Uint8Array(Buffer.from(testAccount.key, 'hex'))
-      const directResult = deriveContextHash(privKeyBytes, parseHexContext('deadbeef'))
+      const directResult = deriveContextHash(privKeyBytes, APP_NAME, parseHexContext('deadbeef'))
       expect(result).toBe(directResult)
-    })
-
-    it('known-answer test', async () => {
-      const newKeyring = new SimpleKeyring([testAccount.key])
-      const result = await newKeyring.deriveContextHash(testAccount.address, 'deadbeef')
-      expect(result).toBe('c75cfa090d2681fdde35ebd22330f0476221fb6d2edd9d9afc2953cab0bd1ce2')
     })
 
     it('different accounts produce different results', async () => {
       const newKeyring = new SimpleKeyring()
       await newKeyring.addAccounts(2)
       const accounts = await newKeyring.getAccounts()
-      const result0 = await newKeyring.deriveContextHash(accounts[0], 'deadbeef')
-      const result1 = await newKeyring.deriveContextHash(accounts[1], 'deadbeef')
+      const result0 = await newKeyring.deriveContextHash(accounts[0], APP_NAME, 'deadbeef')
+      const result1 = await newKeyring.deriveContextHash(accounts[1], APP_NAME, 'deadbeef')
       expect(result0).not.toBe(result1)
+    })
+
+    it('different appNames produce different results', async () => {
+      const newKeyring = new SimpleKeyring([testAccount.key])
+      const result1 = await newKeyring.deriveContextHash(testAccount.address, 'app-one', 'deadbeef')
+      const result2 = await newKeyring.deriveContextHash(testAccount.address, 'app-two', 'deadbeef')
+      expect(result1).not.toBe(result2)
     })
 
     it('throws for unknown public key', async () => {
       const newKeyring = new SimpleKeyring([testAccount.key])
       const fakePubkey = '000000000000000000000000000000000000000000000000000000000000000000'
-      await expect(newKeyring.deriveContextHash(fakePubkey, 'deadbeef')).rejects.toThrow(
+      await expect(newKeyring.deriveContextHash(fakePubkey, APP_NAME, 'deadbeef')).rejects.toThrow(
         'Unable to find matching publicKey'
       )
     })
 
     it('rejects invalid hex context', async () => {
       const newKeyring = new SimpleKeyring([testAccount.key])
-      await expect(newKeyring.deriveContextHash(testAccount.address, 'xyz')).rejects.toThrow()
-      await expect(newKeyring.deriveContextHash(testAccount.address, '')).rejects.toThrow()
-      await expect(newKeyring.deriveContextHash(testAccount.address, 'abc')).rejects.toThrow()
+      await expect(newKeyring.deriveContextHash(testAccount.address, APP_NAME, 'xyz')).rejects.toThrow()
+      await expect(newKeyring.deriveContextHash(testAccount.address, APP_NAME, '')).rejects.toThrow()
+      await expect(newKeyring.deriveContextHash(testAccount.address, APP_NAME, 'abc')).rejects.toThrow()
     })
   })
 })

--- a/packages/wallet-background/src/controllers/provider/controller.ts
+++ b/packages/wallet-background/src/controllers/provider/controller.ts
@@ -541,29 +541,47 @@ class ProviderController extends BaseController {
     'DeriveContextHash',
     async req => {
       const params: RequestMethodDeriveContextHashParams = req.data.params
-      if (!params.context) {
-        throw new Error('context is required')
+      // Validate appName
+      if (!params.appName || typeof params.appName !== 'string') {
+        throw new Error('appName is required and must be a string')
       }
-      if (typeof params.context !== 'string') {
-        throw new Error('context must be a string')
+      if (params.appName.length === 0) {
+        throw new Error('appName must be non-empty')
+      }
+      const appNameBytes = new TextEncoder().encode(params.appName)
+      if (appNameBytes.length > 64) {
+        throw new Error('appName must be at most 64 bytes')
+      }
+      if (!/^[a-z0-9\-]+$/.test(params.appName)) {
+        throw new Error('appName must contain only lowercase letters, digits, and hyphens')
+      }
+      // Validate context
+      if (!params.context || typeof params.context !== 'string') {
+        throw new Error('context is required and must be a string')
       }
       if (params.context.length === 0) {
         throw new Error('context must be non-empty')
       }
+      if (params.context.startsWith('0x') || params.context.startsWith('0X')) {
+        throw new Error('context must not have a 0x prefix')
+      }
       if (params.context.length % 2 !== 0) {
         throw new Error('context must be an even-length hex string')
       }
-      if (!/^[0-9a-fA-F]+$/.test(params.context)) {
-        throw new Error('context must be a valid hex string')
+      if (params.context.length > 2048) {
+        throw new Error('context must not exceed 2048 hex characters (1024 bytes)')
+      }
+      if (!/^[0-9a-f]+$/.test(params.context)) {
+        throw new Error('context must be a lowercase hex string')
       }
     },
   ])
   deriveContextHash = async ({
     data: {
-      params: { context },
+      params: { appName, context },
     },
   }) => {
-    return await wallet.deriveContextHash(context)
+    return await wallet.deriveContextHash(appName, context)
   }
 }
 

--- a/packages/wallet-background/src/controllers/provider/methodList.ts
+++ b/packages/wallet-background/src/controllers/provider/methodList.ts
@@ -41,6 +41,7 @@ export type ProviderMethodList = {
     data: string
   }
   deriveContextHash: {
+    appName: string
     context: string
   }
 }

--- a/packages/wallet-background/src/controllers/wallet.ts
+++ b/packages/wallet-background/src/controllers/wallet.ts
@@ -1009,14 +1009,14 @@ export class WalletController extends BaseController {
     }
   }
 
-  deriveContextHash = async (context: string): Promise<string> => {
+  deriveContextHash = async (appName: string, context: string): Promise<string> => {
     const account = preferenceService.getCurrentAccount()
     if (!account) throw new Error('no current account')
     const keyring = await keyringService.getKeyringForAccount(account.pubkey, account.type)
     if (!keyring.deriveContextHash) {
       throw new Error('Current keyring does not support deriveContextHash')
     }
-    return keyring.deriveContextHash(account.pubkey, context)
+    return keyring.deriveContextHash(account.pubkey, appName, context)
   }
 
   addContact = (data: ContactBookItem) => {

--- a/packages/wallet-shared/src/types/request-method.ts
+++ b/packages/wallet-shared/src/types/request-method.ts
@@ -96,5 +96,6 @@ export interface RequestMethodGetAvailableUtxosParams {
 }
 
 export interface RequestMethodDeriveContextHashParams {
+  appName: string
   context: string
 }


### PR DESCRIPTION
New appName parameter — mandatory application identifier providing app-level domain separation. Must be 1–64
bytes, [a-z0-9-] only. Displayed in the approval dialog so users can see which application is requesting the
derivation.

IKM derivation — HD keyrings (mnemonic/xpriv) now derive the HKDF input key from BIP-32 path m/73681862'
(purpose index = trunc31_be(SHA-256("derive-context-hash"))). Imported private keys use the raw key directly
since they lack a BIP-32 hierarchy.

Info field construction — info = SHA-256(UTF8(appName)) || contextBytes. Hashing appName into a fixed 32-byte
prefix eliminates length-confusion collisions between different appName/context combinations.

Stricter validation — context must be lowercase hex, no 0x prefix, max 2048 hex characters. Validation enforced
at both the provider controller and core function layers.


Plz refer to the spec: https://github.com/babylonlabs-io/babylon-toolkit/pull/1352/changes


<img width="480" height="654" alt="image" src="https://github.com/user-attachments/assets/3e1f4cad-0555-46d5-a71a-ba772dea1741" />
