### PR TITLE
feat(keyring): switch deriveContextHash to per-account-xpub semantics

### DIFF
--- a/docs/api/derive-context-hash.md
+++ b/docs/api/derive-context-hash.md
@@ -10,7 +10,7 @@
 unisat.deriveContextHash(appName, context)
 ```
 
-Derive a deterministic 32-byte value from the connected account's key material, an application name, and an arbitrary context string. The derivation uses HKDF-SHA-256 (RFC 5869).
+Derive a deterministic 32-byte value from the connected leaf's key material, an application name, and an arbitrary context string. The derivation uses HKDF-SHA-256 (RFC 5869).
 
 **Requires user approval** — the wallet will show a confirmation dialog displaying the application name, context string, and requesting origin before deriving the value.
 
@@ -28,27 +28,24 @@ Derive a deterministic 32-byte value from the connected account's key material, 
 **Derivation Scheme**
 
 ```
-ikm    = the connected account's 32-byte private key
+ikm    = the connected leaf's 32-byte private key
 salt   = "derive-context-hash"
 info   = SHA-256(UTF8(appName)) || decode_hex(context)
 output = HKDF-SHA-256(ikm, salt, info, 32)
 ```
 
-Where `ikm` is the connected account's private key:
-- For mnemonic wallets: the BIP-32 private key at the **account-level node** `m/purpose'/coin_type'/account'` (3-deep, hardened) — e.g. `m/44'/0'/0'` for default BIP-44 account 0; `m/86'/0'/0'` for Taproot account 0. All receive addresses under the same account share the same IKM.
-- For imported xpriv wallets: the imported xpriv's own private key (the imported xpriv represents the user's account identity).
+Where `ikm` is the connected receive address's private key:
+- For mnemonic / xpriv wallets: the BIP-32 leaf private key at the receive-address path (e.g. `m/44'/0'/0'/0/0` for the first receive address of a BIP-44 account 0).
 - For imported raw private key wallets: the raw 32-byte private key.
 
 The `info` field is constructed by concatenating SHA-256(UTF8(appName)) (32 bytes, fixed-length) with the raw context bytes decoded from hex. Hashing appName ensures a fixed 32-byte prefix, eliminating length-confusion collisions.
 
-**Output semantics — per-account-xpub**
+**Output semantics — per-public-key**
 
-Output is bound to the connected account's xpub. Within one wallet:
-- Different receive addresses under the same account → **same** output.
-- Different account index, address type (BIP-44 vs BIP-86, etc.), or imported xpriv → **different** output.
-- BIP-39 passphrase change → different seed → different output.
-
-dApps that need per-address (rather than per-account) differentiation should encode the address into `context` themselves.
+Output is bound to the connected leaf's public key:
+- Different connected receive addresses (different leaf pubkeys) → **different** output, even within the same wallet.
+- Same connected leaf called twice → **same** output.
+- Different mnemonic, BIP-39 passphrase, address type, account index, or network → different output (different leaf path → different leaf pubkey).
 
 ---
 
@@ -60,7 +57,7 @@ try {
   const context = "a1b2c3d4e5f6..."; // hex-encoded context
   const hash = await window.unisat.deriveContextHash(appName, context);
   console.log(hash);
-  // 64 lowercase hex chars (depends on the connected account's key material)
+  // 64 lowercase hex chars (depends on the connected leaf's key material)
 } catch (e) {
   console.log(e);
 }

--- a/docs/api/derive-context-hash.md
+++ b/docs/api/derive-context-hash.md
@@ -10,7 +10,7 @@
 unisat.deriveContextHash(appName, context)
 ```
 
-Derive a deterministic 32-byte value from the wallet's key material, an application name, and an arbitrary context string. The derivation uses HKDF-SHA-256 (RFC 5869).
+Derive a deterministic 32-byte value from the connected account's key material, an application name, and an arbitrary context string. The derivation uses HKDF-SHA-256 (RFC 5869).
 
 **Requires user approval** — the wallet will show a confirmation dialog displaying the application name, context string, and requesting origin before deriving the value.
 
@@ -28,17 +28,27 @@ Derive a deterministic 32-byte value from the wallet's key material, an applicat
 **Derivation Scheme**
 
 ```
-ikm    = BIP-32 private key at m/73681862' (32 bytes)
+ikm    = the connected account's 32-byte private key
 salt   = "derive-context-hash"
 info   = SHA-256(UTF8(appName)) || decode_hex(context)
 output = HKDF-SHA-256(ikm, salt, info, 32)
 ```
 
-Where `ikm` is:
-- For mnemonic/xpriv wallets: the 32-byte private key scalar at BIP-32 path `m/73681862'` (hardened), derived from the wallet's HD root.
-- For imported key wallets: the raw 32-byte private key directly (no BIP-32 derivation, since imported keys lack a BIP-32 hierarchy).
+Where `ikm` is the connected account's private key:
+- For mnemonic wallets: the BIP-32 private key at the **account-level node** `m/purpose'/coin_type'/account'` (3-deep, hardened) — e.g. `m/44'/0'/0'` for default BIP-44 account 0; `m/86'/0'/0'` for Taproot account 0. All receive addresses under the same account share the same IKM.
+- For imported xpriv wallets: the imported xpriv's own private key (the imported xpriv represents the user's account identity).
+- For imported raw private key wallets: the raw 32-byte private key.
 
 The `info` field is constructed by concatenating SHA-256(UTF8(appName)) (32 bytes, fixed-length) with the raw context bytes decoded from hex. Hashing appName ensures a fixed 32-byte prefix, eliminating length-confusion collisions.
+
+**Output semantics — per-account-xpub**
+
+Output is bound to the connected account's xpub. Within one wallet:
+- Different receive addresses under the same account → **same** output.
+- Different account index, address type (BIP-44 vs BIP-86, etc.), or imported xpriv → **different** output.
+- BIP-39 passphrase change → different seed → different output.
+
+dApps that need per-address (rather than per-account) differentiation should encode the address into `context` themselves.
 
 ---
 
@@ -50,7 +60,7 @@ try {
   const context = "a1b2c3d4e5f6..."; // hex-encoded context
   const hash = await window.unisat.deriveContextHash(appName, context);
   console.log(hash);
-  // => "3b0e2d90a01122eed8a520648073892f6b2d8f4419216023d63cdbd49500fca3"
+  // 64 lowercase hex chars (depends on the connected account's key material)
 } catch (e) {
   console.log(e);
 }

--- a/docs/api/derive-context-hash.md
+++ b/docs/api/derive-context-hash.md
@@ -45,7 +45,8 @@ The `info` field is constructed by concatenating SHA-256(UTF8(appName)) (32 byte
 Output is bound to the connected leaf's public key:
 - Different connected receive addresses (different leaf pubkeys) → **different** output, even within the same wallet.
 - Same connected leaf called twice → **same** output.
-- Different mnemonic, BIP-39 passphrase, address type, account index, or network → different output (different leaf path → different leaf pubkey).
+- Different mnemonic, BIP-39 passphrase, address type, or account index → different output (different leaf path → different leaf pubkey).
+- Switching mainnet ↔ testnet does **not** rotate the output: UniSat uses BIP-44 `coin_type = 0` paths for both, so the leaf private key is unchanged across networks. Applications that need network-bound outputs MUST encode the network in the `context`.
 
 ---
 
@@ -73,6 +74,10 @@ try {
 - The fixed salt `"derive-context-hash"` provides domain separation from BIP-32 and other HMAC uses.
 - SHA-256(appName) prefix in the info field provides mandatory app-level domain separation.
 - All intermediate key material is zeroed after use within the wallet.
+
+**Known divergence from spec v2.0**
+
+Spec v2.0 §2.2 requires that a wallet return an error when BIP-32 child derivation produces an invalid key (`IL ≥ n` or `kpar + IL ≡ 0 mod n`), rather than advancing to the next index. UniSat's BIP-32 derivation is provided by the `hdkey` library, which silently retries with `index + 1` in those cases. This applies to all BIP-32 derivations in the wallet (account creation, signing, and `deriveContextHash`), not just this method. The probability of an invalid child at any given index on secp256k1 is ≈ 2⁻¹²⁷ and has not been observed in practice. Cross-wallet reproducibility against another conforming wallet would diverge only if both wallets attempt to use the same astronomically-rare invalid leaf path; standard receive-address paths are unaffected.
 
 **Use Cases**
 

--- a/docs/releases/release-notes.md
+++ b/docs/releases/release-notes.md
@@ -1,5 +1,12 @@
 # UniSat Wallet Release Notes
 
+## Unreleased
+
+### Breaking Changes (Experimental API)
+
+- **`unisat.deriveContextHash` IKM source changed (spec v1.0 → v2.0).** The 32-byte derived value is now bound to the connected leaf's public key instead of a fixed wallet-level BIP-32 path (`m/73681862'`). For HD wallets the IKM is now the leaf private key at the active receive-address path (e.g. `m/44'/0'/0'/0/0`); for imported wallets the behavior is unchanged. Output is **per-public-key**: switching the connected receive address (different index, account, or address type) now yields a different output. Switching mainnet ↔ testnet still returns the same value because UniSat uses `coin_type = 0` for both networks; applications that need network-bound outputs MUST encode the network in the `context`.
+- **Outputs change for any prior caller.** Any dApp that persisted v1.0 outputs (e.g. an HTLC pre-image, a Lamport seed) must re-derive against v2.0 — there is no version-discovery mechanism. The API remains marked `@experimental`. See [`../api/derive-context-hash.md`](../api/derive-context-hash.md) for the updated contract.
+
 ## v1.7.13
 
 ### Improvements

--- a/packages/keyring-service/README.md
+++ b/packages/keyring-service/README.md
@@ -135,7 +135,7 @@ Main service class for managing keyrings.
 
 ##### Key Derivation
 
-- `deriveContextHash(publicKey: string, appName: string, context: string): Promise<string>` - Derive a deterministic 32-byte value from the wallet's key material, an application name, and a hex-encoded context string using HKDF-SHA-256 (RFC 5869). The `appName` must be 1-64 bytes, lowercase `[a-z0-9\-]`. Supported by all keyring types: HD (mnemonic), HD (xpriv), and imported private keys.
+- `deriveContextHash(publicKey: string, appName: string, context: string): Promise<string>` - Derive a deterministic 32-byte value bound to the connected leaf's public key, using HKDF-SHA-256 (RFC 5869). For HD keyrings (mnemonic / xpriv), IKM is the BIP-32 leaf private key whose public key matches `publicKey`; for imported keyrings, IKM is the raw imported private key. Different connected leaves produce different outputs; the same leaf called twice returns the same output. The `appName` must be 1-64 bytes, lowercase `[a-z0-9\-]`. Supported by HD (mnemonic), HD (xpriv), and imported keyrings.
 
 ### Types
 

--- a/packages/keyring-service/src/keyrings/derive-context-hash.ts
+++ b/packages/keyring-service/src/keyrings/derive-context-hash.ts
@@ -1,19 +1,19 @@
 /**
  * Deterministic context-based key derivation using HKDF (RFC 5869).
  *
- * ## Derivation scheme (account-level)
+ * ## Derivation scheme (per-public-key)
  *
  * ```
- * ikm    = the connected account's 32-byte private key
+ * ikm    = the connected leaf's 32-byte private key
  * salt   = "derive-context-hash"
  * info   = SHA-256(UTF8(appName)) || contextBytes
  * output = HKDF-SHA-256(ikm, salt, info, 32)
  * ```
  *
- * For HD wallets, the IKM is the BIP-32 private key at the **account-level**
- * node m/purpose'/coin_type'/account' (3-deep, hardened) — i.e. all receive
- * addresses under the same xpub share the same IKM. For imported wallets,
- * the IKM is the raw imported private key.
+ * For HD wallets, the IKM is the connected leaf private key (the BIP-32
+ * leaf at the receive-address path). Different leaves (different leaf
+ * pubkeys) produce different secrets. For imported wallets, the IKM is
+ * the raw imported private key.
  *
  * @module derive-context-hash
  */

--- a/packages/keyring-service/src/keyrings/derive-context-hash.ts
+++ b/packages/keyring-service/src/keyrings/derive-context-hash.ts
@@ -1,14 +1,19 @@
 /**
  * Deterministic context-based key derivation using HKDF (RFC 5869).
  *
- * ## Derivation scheme (spec v1.0, algorithm version 0)
+ * ## Derivation scheme (account-level)
  *
  * ```
- * ikm    = 32-byte private key (BIP-32 derived at m/73681862' or raw imported key)
+ * ikm    = the connected account's 32-byte private key
  * salt   = "derive-context-hash"
  * info   = SHA-256(UTF8(appName)) || contextBytes
  * output = HKDF-SHA-256(ikm, salt, info, 32)
  * ```
+ *
+ * For HD wallets, the IKM is the BIP-32 private key at the **account-level**
+ * node m/purpose'/coin_type'/account' (3-deep, hardened) — i.e. all receive
+ * addresses under the same xpub share the same IKM. For imported wallets,
+ * the IKM is the raw imported private key.
  *
  * @module derive-context-hash
  */

--- a/packages/keyring-service/src/keyrings/hd-keyring.ts
+++ b/packages/keyring-service/src/keyrings/hd-keyring.ts
@@ -9,8 +9,6 @@ import { deriveContextHash, parseHexContext } from './derive-context-hash'
 import { SimpleKeyring } from './simple-keyring'
 
 const hdPathString = "m/44'/0'/0'/0"
-// BIP-32 path for deriveContextHash IKM. Purpose index = trunc31_be(SHA-256("derive-context-hash")).
-const DERIVE_CONTEXT_HASH_PATH = "m/73681862'"
 const type = 'HD Key Tree'
 
 interface DeserializeOption {
@@ -265,28 +263,68 @@ export class HdKeyring extends SimpleKeyring {
   }
 
   /**
-   * Derive a deterministic context hash from the wallet's key material.
-   * Uses BIP-32 derivation at m/73681862' from the HD wallet root.
+   * Derive a deterministic context hash bound to the connected BIP-32
+   * account-level node (3-deep, hardened: m/purpose'/coin_type'/account').
    *
-   * @param _publicKey - Unused for HD keyrings (derivation is from root).
-   * @param appName - Application identifier.
-   * @param context - Hex-encoded context string.
+   * Per-account semantics: all receive addresses under the same account
+   * share the same output; switching account index, purpose (address type),
+   * or imported xpriv changes the output.
+   *
+   * The leaf-index lookup and account-path resolution are intentionally
+   * inlined rather than extracted to shared helpers — deriveContextHash's
+   * output is a deterministic secret whose bytes must remain stable across
+   * the wallet's lifetime, so we keep its derivation isolated from any
+   * future modification of unrelated lookup or path-mapping helpers.
    */
-  override async deriveContextHash(_publicKey: string, appName: string, context: string): Promise<string> {
+  override async deriveContextHash(publicKey: string, appName: string, context: string): Promise<string> {
     const contextBytes = parseHexContext(context)
     if (!this.hdWallet) {
-      throw new Error('deriveContextHash requires a mnemonic or xpriv-based keyring')
+      throw new Error('deriveContextHash requires an initialized HD keyring')
     }
-    const child = this.hdWallet.derive(DERIVE_CONTEXT_HASH_PATH)
-    const privKeyBytes = new Uint8Array(child.privateKey)
+
+    // Find which leaf the connected pubkey corresponds to.
+    let leafIndex: number | null = null
+    for (const key in this._index2wallet) {
+      const entry = this._index2wallet[key]
+      if (entry && entry[1].publicKey.toString('hex') === publicKey) {
+        leafIndex = Number(key)
+        break
+      }
+    }
+    if (leafIndex === null) {
+      throw new Error('deriveContextHash: Unable to find matching publicKey')
+    }
+
+    // Resolve the BIP-32 account-level (3-deep, hardened) node.
+    let accountNode: any
+    if (this.xpriv) {
+      // An imported xpriv represents the user's account identity at
+      // whatever depth they imported.
+      accountNode = this.hdWallet
+    } else {
+      // _buildAccountLevelPath is the canonical path mapper used by
+      // address derivation; reuse it here so any future BIP-32 path
+      // convention change ripples consistently.
+      const basePath = this.accountIndexDerivation
+        ? this._buildAccountLevelPath(this.hdPath, leafIndex)
+        : this.hdPath
+      const segments = basePath.split('/')
+      if (segments.length < 4) {
+        throw new Error('deriveContextHash: hdPath must have at least 3 hardened components')
+      }
+      segments.length = 4 // m/purpose'/coin_type'/account'
+      accountNode = this.hdWallet.derive(segments.join('/'))
+    }
+
+    if (!accountNode.privateKey) {
+      throw new Error('deriveContextHash: account-level BIP-32 node has no private key')
+    }
+
+    const privKeyBytes = new Uint8Array(accountNode.privateKey)
     try {
       return deriveContextHash(privKeyBytes, appName, contextBytes)
     } finally {
       privKeyBytes.fill(0)
-      // Zero the original BIP-32 node's key buffer as well
-      if (child.privateKey) {
-        child.privateKey.fill(0)
-      }
     }
   }
 

--- a/packages/keyring-service/src/keyrings/hd-keyring.ts
+++ b/packages/keyring-service/src/keyrings/hd-keyring.ts
@@ -263,68 +263,36 @@ export class HdKeyring extends SimpleKeyring {
   }
 
   /**
-   * Derive a deterministic context hash bound to the connected BIP-32
-   * account-level node (3-deep, hardened: m/purpose'/coin_type'/account').
+   * Derive a deterministic context hash bound to the connected leaf
+   * public key. IKM is the leaf private key, so different receive
+   * addresses (different leaf pubkeys) produce different secrets — the
+   * same connected pubkey called twice produces the same secret.
    *
-   * Per-account semantics: all receive addresses under the same account
-   * share the same output; switching account index, purpose (address type),
-   * or imported xpriv changes the output.
-   *
-   * The leaf-index lookup and account-path resolution are intentionally
-   * inlined rather than extracted to shared helpers — deriveContextHash's
-   * output is a deterministic secret whose bytes must remain stable across
-   * the wallet's lifetime, so we keep its derivation isolated from any
-   * future modification of unrelated lookup or path-mapping helpers.
+   * Implementation is kept self-contained (independent of SimpleKeyring's
+   * inheritance) — this method's output stability is a forever invariant,
+   * so we don't want it perturbed by future modifications to unrelated
+   * code paths.
    */
   override async deriveContextHash(publicKey: string, appName: string, context: string): Promise<string> {
     const contextBytes = parseHexContext(context)
-    if (!this.hdWallet) {
-      throw new Error('deriveContextHash requires an initialized HD keyring')
-    }
 
-    // Find which leaf the connected pubkey corresponds to.
-    let leafIndex: number | null = null
-    for (const key in this._index2wallet) {
-      const entry = this._index2wallet[key]
-      if (entry && entry[1].publicKey.toString('hex') === publicKey) {
-        leafIndex = Number(key)
+    // Find the leaf ECPair whose public key matches the connected pubkey.
+    let leafPrivateKey: Buffer | undefined
+    for (const wallet of this.wallets) {
+      if (wallet.publicKey.toString('hex') === publicKey) {
+        leafPrivateKey = wallet.privateKey
         break
       }
     }
-    if (leafIndex === null) {
+    if (!leafPrivateKey) {
       throw new Error('deriveContextHash: Unable to find matching publicKey')
     }
 
-    // Resolve the BIP-32 account-level (3-deep, hardened) node.
-    let accountNode: any
-    if (this.xpriv) {
-      // An imported xpriv represents the user's account identity at
-      // whatever depth they imported.
-      accountNode = this.hdWallet
-    } else {
-      // _buildAccountLevelPath is the canonical path mapper used by
-      // address derivation; reuse it here so any future BIP-32 path
-      // convention change ripples consistently.
-      const basePath = this.accountIndexDerivation
-        ? this._buildAccountLevelPath(this.hdPath, leafIndex)
-        : this.hdPath
-      const segments = basePath.split('/')
-      if (segments.length < 4) {
-        throw new Error('deriveContextHash: hdPath must have at least 3 hardened components')
-      }
-      segments.length = 4 // m/purpose'/coin_type'/account'
-      accountNode = this.hdWallet.derive(segments.join('/'))
-    }
-
-    if (!accountNode.privateKey) {
-      throw new Error('deriveContextHash: account-level BIP-32 node has no private key')
-    }
-
-    const privKeyBytes = new Uint8Array(accountNode.privateKey)
+    const ikmBytes = new Uint8Array(leafPrivateKey)
     try {
-      return deriveContextHash(privKeyBytes, appName, contextBytes)
+      return deriveContextHash(ikmBytes, appName, contextBytes)
     } finally {
-      privKeyBytes.fill(0)
+      ikmBytes.fill(0)
     }
   }
 

--- a/packages/keyring-service/test/derive-context-hash.test.ts
+++ b/packages/keyring-service/test/derive-context-hash.test.ts
@@ -62,9 +62,11 @@ describe('deriveContextHash', () => {
     })
   })
 
-  describe('known-answer tests (spec vectors)', () => {
-    // Spec test vectors use BIP-39 mnemonic "abandon...about" (no passphrase)
-    // IKM = BIP-32 private key at m/73681862'
+  describe('known-answer tests (HKDF function-level)', () => {
+    // These vectors pin the pure HKDF composition (ikm, appName, context).
+    // They are independent of how the keyring sources IKM at runtime — the
+    // keyring layer's contract (account-level vs wallet-level) is tested in
+    // the keyring-specific test files.
     const IKM_HEX = '391cdb922097ec9c96fc13cadb01d5745ccf31f5dbec3a38103440714779ec85'
     const ikm = new Uint8Array(Buffer.from(IKM_HEX, 'hex'))
 

--- a/packages/keyring-service/test/derive-context-hash.test.ts
+++ b/packages/keyring-service/test/derive-context-hash.test.ts
@@ -65,8 +65,8 @@ describe('deriveContextHash', () => {
   describe('known-answer tests (HKDF function-level)', () => {
     // These vectors pin the pure HKDF composition (ikm, appName, context).
     // They are independent of how the keyring sources IKM at runtime — the
-    // keyring layer's contract (account-level vs wallet-level) is tested in
-    // the keyring-specific test files.
+    // keyring layer's contract (per-public-key) is tested in the
+    // keyring-specific test files.
     const IKM_HEX = '391cdb922097ec9c96fc13cadb01d5745ccf31f5dbec3a38103440714779ec85'
     const ikm = new Uint8Array(Buffer.from(IKM_HEX, 'hex'))
 

--- a/packages/keyring-service/test/hd-keyring.test.ts
+++ b/packages/keyring-service/test/hd-keyring.test.ts
@@ -299,7 +299,7 @@ describe('bitcoin-hd-keyring', () => {
       expect(result).toMatch(/^[0-9a-f]{64}$/)
     })
 
-    it('produces same result as direct derivation at the account-level (3-deep) BIP-32 node', async () => {
+    it('produces same result as direct derivation with the connected leaf private key', async () => {
       const keyring = new HdKeyring({
         mnemonic: sampleMnemonic,
         activeIndexes: [0],
@@ -308,50 +308,34 @@ describe('bitcoin-hd-keyring', () => {
       const contextHex = 'deadbeef'
       const keyringResult = await keyring.deriveContextHash(accounts[0], APP_NAME, contextHex)
 
-      // IKM = the BIP-32 private key at the account-level node
-      // m/purpose'/coin'/account' (3-deep) — for the default hdPath
-      // "m/44'/0'/0'/0", that's "m/44'/0'/0'".
+      // IKM = the BIP-32 leaf private key at the connected receive address.
+      // For default hdPath "m/44'/0'/0'/0" + index 0, leaf is "m/44'/0'/0'/0/0".
       const bip39 = await import('bip39')
       const hdkey = await import('hdkey')
       const seedBuf = bip39.mnemonicToSeedSync(sampleMnemonic)
       const master = hdkey.fromMasterSeed(seedBuf)
-      const accountNode = master.derive("m/44'/0'/0'")
-      const privKey = new Uint8Array(accountNode.privateKey)
+      const leaf = master.derive("m/44'/0'/0'/0/0")
+      const privKey = new Uint8Array(leaf.privateKey)
       const directResult = deriveContextHash(privKey, APP_NAME, parseHexContext(contextHex))
       expect(keyringResult).toBe(directResult)
     })
 
-    it('default mode: different leaves under the same account share the same hash', async () => {
-      // Default hdPath "m/44'/0'/0'/0" — leaves 0 and 1 are addresses under
-      // the same account-level node m/44'/0'/0'. Output must match.
+    it('different leaf pubkeys produce different hashes (per-public-key)', async () => {
+      // Two leaves at "m/44'/0'/0'/0/0" and "m/44'/0'/0'/0/1" — different
+      // leaf pubkeys → different secrets.
       const keyring = new HdKeyring({
         mnemonic: sampleMnemonic,
         activeIndexes: [0, 1],
       })
       const accounts = await keyring.getAccounts()
-      const result0 = await keyring.deriveContextHash(accounts[0], APP_NAME, 'deadbeef')
-      const result1 = await keyring.deriveContextHash(accounts[1], APP_NAME, 'deadbeef')
-      expect(result0).toBe(result1)
-      expect(result0).toMatch(/^[0-9a-f]{64}$/)
-    })
-
-    it('accountIndexDerivation mode: different account indices produce different hashes', async () => {
-      // hdPath "m/84'/0'/0'/0" with accountIndexDerivation — leaf i lives
-      // under m/84'/0'/i', so leaves 0 and 1 are different accounts and
-      // MUST produce different hashes.
-      const keyring = new HdKeyring({
-        mnemonic: sampleMnemonic,
-        hdPath: "m/84'/0'/0'/0",
-        accountIndexDerivation: true,
-        activeIndexes: [0, 1],
-      })
-      const accounts = await keyring.getAccounts()
+      expect(accounts[0]).not.toBe(accounts[1])
       const result0 = await keyring.deriveContextHash(accounts[0], APP_NAME, 'deadbeef')
       const result1 = await keyring.deriveContextHash(accounts[1], APP_NAME, 'deadbeef')
       expect(result0).not.toBe(result1)
+      expect(result0).toMatch(/^[0-9a-f]{64}$/)
     })
 
-    it('changing hdPath (BIP standard) rotates the account-level secret', async () => {
+    it('changing hdPath rotates the secret', async () => {
       const keyringBip44 = new HdKeyring({
         mnemonic: sampleMnemonic,
         hdPath: "m/44'/0'/0'/0",
@@ -369,7 +353,7 @@ describe('bitcoin-hd-keyring', () => {
       expect(result44).not.toBe(result86)
     })
 
-    it('mnemonic keyring produces identical result for the same account pubkey across calls', async () => {
+    it('mnemonic keyring produces identical result for the same leaf pubkey across calls', async () => {
       const keyring = new HdKeyring({
         mnemonic: sampleMnemonic,
         activeIndexes: [0],
@@ -414,7 +398,7 @@ describe('bitcoin-hd-keyring', () => {
       expect(result1).toBe(result2)
     })
 
-    it('xpriv keyring: different leaves share the same hash (one xpriv = one identity)', async () => {
+    it('xpriv keyring: different leaf pubkeys produce different hashes', async () => {
       const sampleXpriv =
         'xprvA2JBuYsdqVhrC2wGmb9QhBejk9gXXYgM3Jg9xgVYmDMsakDoURc8V7UYos1pP1kev1tG51PPA9A8VMYYCLov1L5c3J7npraxwjeJCquGhDi'
       const keyring = new HdKeyring({
@@ -422,9 +406,10 @@ describe('bitcoin-hd-keyring', () => {
         activeIndexes: [0, 1],
       })
       const accounts = await keyring.getAccounts()
+      expect(accounts[0]).not.toBe(accounts[1])
       const result0 = await keyring.deriveContextHash(accounts[0], APP_NAME, 'deadbeef')
       const result1 = await keyring.deriveContextHash(accounts[1], APP_NAME, 'deadbeef')
-      expect(result0).toBe(result1)
+      expect(result0).not.toBe(result1)
     })
 
     it('rejects invalid hex context', async () => {
@@ -438,14 +423,7 @@ describe('bitcoin-hd-keyring', () => {
       await expect(keyring.deriveContextHash(accounts[0], APP_NAME, 'abc')).rejects.toThrow()
     })
 
-    it('rejects when keyring is uninitialized', async () => {
-      const keyring = new HdKeyring()
-      await expect(keyring.deriveContextHash('anypubkey', APP_NAME, 'deadbeef')).rejects.toThrow(
-        'requires an initialized HD keyring'
-      )
-    })
-
-    it('rejects unknown publicKey on an initialized keyring', async () => {
+    it('rejects unknown publicKey', async () => {
       const keyring = new HdKeyring({
         mnemonic: sampleMnemonic,
         activeIndexes: [0],
@@ -456,13 +434,12 @@ describe('bitcoin-hd-keyring', () => {
       )
     })
 
-    // KAT: IKM = the BIP-32 private key at the account-level node
-    // m/44'/0'/0' (3-deep, hardened) from the standard BIP-39 test mnemonic
+    // KAT: IKM = the BIP-32 leaf private key at "m/44'/0'/0'/0/0" (default
+    // hdPath + child index 0) from the standard BIP-39 test mnemonic
     // "abandon abandon abandon abandon abandon abandon abandon abandon abandon
-    // abandon abandon about" (no passphrase). This is the canonical
-    // cross-wallet interop fixture: any conforming wallet that connects this
-    // mnemonic with default BIP-44 hdPath must produce this exact output.
-    it('spec vector: known mnemonic, BIP-44 account 0, appName=test-app, context=deadbeef', async () => {
+    // abandon abandon about" (no passphrase). Cross-wallet interop fixture:
+    // any conforming wallet connected to this leaf produces this exact value.
+    it('spec vector: known mnemonic, BIP-44 leaf 0/0, appName=test-app, context=deadbeef', async () => {
       const knownMnemonic =
         'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
       const keyring = new HdKeyring({
@@ -471,7 +448,7 @@ describe('bitcoin-hd-keyring', () => {
       })
       const accounts = await keyring.getAccounts()
       const result = await keyring.deriveContextHash(accounts[0], 'test-app', 'deadbeef')
-      expect(result).toBe('2909f0c437a8a8b51206ac02a3abb88a1656a2266ec05c0102ae2209c3f2a30c')
+      expect(result).toBe('650b3fa2cf958ecd258544af2b812c3e8a3f4f75ea5d030cb4dd175da551e356')
     })
   })
 

--- a/packages/keyring-service/test/hd-keyring.test.ts
+++ b/packages/keyring-service/test/hd-keyring.test.ts
@@ -299,7 +299,7 @@ describe('bitcoin-hd-keyring', () => {
       expect(result).toMatch(/^[0-9a-f]{64}$/)
     })
 
-    it('produces same result as direct derivation with BIP-32 derived key', async () => {
+    it('produces same result as direct derivation at the account-level (3-deep) BIP-32 node', async () => {
       const keyring = new HdKeyring({
         mnemonic: sampleMnemonic,
         activeIndexes: [0],
@@ -308,18 +308,22 @@ describe('bitcoin-hd-keyring', () => {
       const contextHex = 'deadbeef'
       const keyringResult = await keyring.deriveContextHash(accounts[0], APP_NAME, contextHex)
 
-      // Manually derive BIP-32 key at m/73681862' and compute directly
+      // IKM = the BIP-32 private key at the account-level node
+      // m/purpose'/coin'/account' (3-deep) — for the default hdPath
+      // "m/44'/0'/0'/0", that's "m/44'/0'/0'".
       const bip39 = await import('bip39')
       const hdkey = await import('hdkey')
       const seedBuf = bip39.mnemonicToSeedSync(sampleMnemonic)
       const master = hdkey.fromMasterSeed(seedBuf)
-      const child = master.derive("m/73681862'")
-      const privKey = new Uint8Array(child.privateKey)
+      const accountNode = master.derive("m/44'/0'/0'")
+      const privKey = new Uint8Array(accountNode.privateKey)
       const directResult = deriveContextHash(privKey, APP_NAME, parseHexContext(contextHex))
       expect(keyringResult).toBe(directResult)
     })
 
-    it('mnemonic keyring produces same result regardless of which account pubkey is passed', async () => {
+    it('default mode: different leaves under the same account share the same hash', async () => {
+      // Default hdPath "m/44'/0'/0'/0" — leaves 0 and 1 are addresses under
+      // the same account-level node m/44'/0'/0'. Output must match.
       const keyring = new HdKeyring({
         mnemonic: sampleMnemonic,
         activeIndexes: [0, 1],
@@ -328,6 +332,52 @@ describe('bitcoin-hd-keyring', () => {
       const result0 = await keyring.deriveContextHash(accounts[0], APP_NAME, 'deadbeef')
       const result1 = await keyring.deriveContextHash(accounts[1], APP_NAME, 'deadbeef')
       expect(result0).toBe(result1)
+      expect(result0).toMatch(/^[0-9a-f]{64}$/)
+    })
+
+    it('accountIndexDerivation mode: different account indices produce different hashes', async () => {
+      // hdPath "m/84'/0'/0'/0" with accountIndexDerivation — leaf i lives
+      // under m/84'/0'/i', so leaves 0 and 1 are different accounts and
+      // MUST produce different hashes.
+      const keyring = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        hdPath: "m/84'/0'/0'/0",
+        accountIndexDerivation: true,
+        activeIndexes: [0, 1],
+      })
+      const accounts = await keyring.getAccounts()
+      const result0 = await keyring.deriveContextHash(accounts[0], APP_NAME, 'deadbeef')
+      const result1 = await keyring.deriveContextHash(accounts[1], APP_NAME, 'deadbeef')
+      expect(result0).not.toBe(result1)
+    })
+
+    it('changing hdPath (BIP standard) rotates the account-level secret', async () => {
+      const keyringBip44 = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        hdPath: "m/44'/0'/0'/0",
+        activeIndexes: [0],
+      })
+      const keyringBip86 = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        hdPath: "m/86'/0'/0'/0",
+        activeIndexes: [0],
+      })
+      const accounts44 = await keyringBip44.getAccounts()
+      const accounts86 = await keyringBip86.getAccounts()
+      const result44 = await keyringBip44.deriveContextHash(accounts44[0], APP_NAME, 'deadbeef')
+      const result86 = await keyringBip86.deriveContextHash(accounts86[0], APP_NAME, 'deadbeef')
+      expect(result44).not.toBe(result86)
+    })
+
+    it('mnemonic keyring produces identical result for the same account pubkey across calls', async () => {
+      const keyring = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        activeIndexes: [0],
+      })
+      const accounts = await keyring.getAccounts()
+      const a = await keyring.deriveContextHash(accounts[0], APP_NAME, 'deadbeef')
+      const b = await keyring.deriveContextHash(accounts[0], APP_NAME, 'deadbeef')
+      expect(a).toBe(b)
     })
 
     it('xpriv-only keyring derives from BIP-32 path', async () => {
@@ -343,7 +393,7 @@ describe('bitcoin-hd-keyring', () => {
       expect(result).toMatch(/^[0-9a-f]{64}$/)
     })
 
-    it('xpriv result is stable regardless of account activation order', async () => {
+    it('xpriv keyring: same leaf-pubkey produces same hash regardless of activation order', async () => {
       const sampleXpriv =
         'xprvA2JBuYsdqVhrC2wGmb9QhBejk9gXXYgM3Jg9xgVYmDMsakDoURc8V7UYos1pP1kev1tG51PPA9A8VMYYCLov1L5c3J7npraxwjeJCquGhDi'
       const keyring1 = new HdKeyring({
@@ -356,9 +406,25 @@ describe('bitcoin-hd-keyring', () => {
       })
       const accounts1 = await keyring1.getAccounts()
       const accounts2 = await keyring2.getAccounts()
-      const result1 = await keyring1.deriveContextHash(accounts1[0], APP_NAME, 'deadbeef')
-      const result2 = await keyring2.deriveContextHash(accounts2[0], APP_NAME, 'deadbeef')
+      // accounts1[0] = leaf 0, accounts2[1] = leaf 0 — pick the same pubkey.
+      const leafZeroPubkey = accounts1[0]
+      expect(accounts2[1]).toBe(leafZeroPubkey)
+      const result1 = await keyring1.deriveContextHash(leafZeroPubkey, APP_NAME, 'deadbeef')
+      const result2 = await keyring2.deriveContextHash(leafZeroPubkey, APP_NAME, 'deadbeef')
       expect(result1).toBe(result2)
+    })
+
+    it('xpriv keyring: different leaves share the same hash (one xpriv = one identity)', async () => {
+      const sampleXpriv =
+        'xprvA2JBuYsdqVhrC2wGmb9QhBejk9gXXYgM3Jg9xgVYmDMsakDoURc8V7UYos1pP1kev1tG51PPA9A8VMYYCLov1L5c3J7npraxwjeJCquGhDi'
+      const keyring = new HdKeyring({
+        xpriv: sampleXpriv,
+        activeIndexes: [0, 1],
+      })
+      const accounts = await keyring.getAccounts()
+      const result0 = await keyring.deriveContextHash(accounts[0], APP_NAME, 'deadbeef')
+      const result1 = await keyring.deriveContextHash(accounts[1], APP_NAME, 'deadbeef')
+      expect(result0).toBe(result1)
     })
 
     it('rejects invalid hex context', async () => {
@@ -372,14 +438,31 @@ describe('bitcoin-hd-keyring', () => {
       await expect(keyring.deriveContextHash(accounts[0], APP_NAME, 'abc')).rejects.toThrow()
     })
 
-    it('rejects uninitialized keyring', async () => {
+    it('rejects when keyring is uninitialized', async () => {
       const keyring = new HdKeyring()
       await expect(keyring.deriveContextHash('anypubkey', APP_NAME, 'deadbeef')).rejects.toThrow(
-        'requires a mnemonic or xpriv-based keyring'
+        'requires an initialized HD keyring'
       )
     })
 
-    it('spec vector 1 with known mnemonic', async () => {
+    it('rejects unknown publicKey on an initialized keyring', async () => {
+      const keyring = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        activeIndexes: [0],
+      })
+      const unknownPubkey = '02' + 'aa'.repeat(32)
+      await expect(keyring.deriveContextHash(unknownPubkey, APP_NAME, 'deadbeef')).rejects.toThrow(
+        'Unable to find matching publicKey'
+      )
+    })
+
+    // KAT: IKM = the BIP-32 private key at the account-level node
+    // m/44'/0'/0' (3-deep, hardened) from the standard BIP-39 test mnemonic
+    // "abandon abandon abandon abandon abandon abandon abandon abandon abandon
+    // abandon abandon about" (no passphrase). This is the canonical
+    // cross-wallet interop fixture: any conforming wallet that connects this
+    // mnemonic with default BIP-44 hdPath must produce this exact output.
+    it('spec vector: known mnemonic, BIP-44 account 0, appName=test-app, context=deadbeef', async () => {
       const knownMnemonic =
         'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
       const keyring = new HdKeyring({
@@ -388,7 +471,7 @@ describe('bitcoin-hd-keyring', () => {
       })
       const accounts = await keyring.getAccounts()
       const result = await keyring.deriveContextHash(accounts[0], 'test-app', 'deadbeef')
-      expect(result).toBe('3b0e2d90a01122eed8a520648073892f6b2d8f4419216023d63cdbd49500fca3')
+      expect(result).toBe('2909f0c437a8a8b51206ac02a3abb88a1656a2266ec05c0102ae2209c3f2a30c')
     })
   })
 

--- a/packages/keyring-service/test/hd-keyring.test.ts
+++ b/packages/keyring-service/test/hd-keyring.test.ts
@@ -353,6 +353,47 @@ describe('bitcoin-hd-keyring', () => {
       expect(result44).not.toBe(result86)
     })
 
+    it('different account index rotates the secret', async () => {
+      // Spec v2.0 §4.2: "m/44'/0'/0'/0/0" vs "m/44'/0'/1'/0/0" — different
+      // BIP-44 account segment → different leaf pubkey → different output.
+      const keyringAccount0 = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        hdPath: "m/44'/0'/0'/0",
+        activeIndexes: [0],
+      })
+      const keyringAccount1 = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        hdPath: "m/44'/0'/1'/0",
+        activeIndexes: [0],
+      })
+      const accounts0 = await keyringAccount0.getAccounts()
+      const accounts1 = await keyringAccount1.getAccounts()
+      expect(accounts0[0]).not.toBe(accounts1[0])
+      const result0 = await keyringAccount0.deriveContextHash(accounts0[0], APP_NAME, 'deadbeef')
+      const result1 = await keyringAccount1.deriveContextHash(accounts1[0], APP_NAME, 'deadbeef')
+      expect(result0).not.toBe(result1)
+    })
+
+    it('different BIP-39 passphrase rotates the secret', async () => {
+      // Spec v2.0 §4.2: same mnemonic with different BIP-39 passphrase yields
+      // a different seed, hence a different leaf privkey at the same path.
+      const keyringNoPass = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        activeIndexes: [0],
+      })
+      const keyringWithPass = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        passphrase: 'TREZOR',
+        activeIndexes: [0],
+      })
+      const accountsNoPass = await keyringNoPass.getAccounts()
+      const accountsWithPass = await keyringWithPass.getAccounts()
+      expect(accountsNoPass[0]).not.toBe(accountsWithPass[0])
+      const resultNoPass = await keyringNoPass.deriveContextHash(accountsNoPass[0], APP_NAME, 'deadbeef')
+      const resultWithPass = await keyringWithPass.deriveContextHash(accountsWithPass[0], APP_NAME, 'deadbeef')
+      expect(resultNoPass).not.toBe(resultWithPass)
+    })
+
     it('mnemonic keyring produces identical result for the same leaf pubkey across calls', async () => {
       const keyring = new HdKeyring({
         mnemonic: sampleMnemonic,

--- a/packages/wallet-connect/src/providers.ts
+++ b/packages/wallet-connect/src/providers.ts
@@ -29,6 +29,15 @@ export interface UnisatWalletProvider {
   getInscriptions(num: number): Promise<void>;
   getVersion(): Promise<string>;
   pushPsbt(psbt: string): Promise<string>;
+  /**
+   * @experimental
+   * Derive a deterministic 32-byte value bound to the connected leaf's public
+   * key, using HKDF-SHA-256. Output rotates per-connected-leaf (different
+   * receive address, account, or address type → different output). Requires
+   * user approval. May change in future versions; integrators should
+   * feature-detect.
+   */
+  deriveContextHash(appName: string, context: string): Promise<string>;
 }
 
 /**


### PR DESCRIPTION
**NOTE**: This PR is still under discussion for its design.
You can track the discussion around the decision here: https://github.com/babylonlabs-io/babylon-toolkit/pull/1540/changes

**This PR should not be merged until the above PR is agreed and merged.**



## Summary

Changes `deriveContextHash` IKM source from a fixed BIP-32 path
(wallet-level) to the **connected leaf's** private key — the BIP-32 leaf
at the active receive-address path (e.g. `m/44'/0'/0'/0/0`). HD and
imported paths are now symmetric: one connected public key = one IKM =
one output.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Same wallet, different receive addresses | Same | **Different** |
| Same wallet, account 0 vs account 1 | Same | **Different** |
| Same wallet, BIP-44 vs BIP-86 | Same | **Different** |
| Same connected leaf called twice | Same | Same |
| Imported wallets | Per-key | Per-key (unchanged) |

dApps that need cross-leaf shared state (e.g. account-scoped data) must
do that aggregation themselves — they're connecting one address at a
time, so they get exactly one output per connection.

## Breaking change is sanctioned by `@experimental`

`deriveContextHash` is marked **Experimental** in the inpage method,
type registry, API docs, doc index, and release notes. The API docs
explicitly tell integrators to use feature detection. Salt unchanged —
the IKM-source change alone produces independent outputs from v1.0.

## Implementation note

The HD-keyring lookup matches the connected pubkey against the keyring's
existing leaf wallets and uses that leaf's private key directly as IKM.
No new BIP-32 derivation path; reuses whatever path the keyring is
already authorized for.


Spec updates: https://github.com/babylonlabs-io/babylon-toolkit/pull/1540