### PR TITLE
Proposed Security fixes based on debate with another bitcoin community member

### DIFF
--- a/apps/extension/build/_raw/manifest/_base_v2.json
+++ b/apps/extension/build/_raw/manifest/_base_v2.json
@@ -40,6 +40,6 @@
       "all_frames": true
     }
   ],
-  "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",
-  "web_accessible_resources": ["pageProvider.js", "index.html"]
+  "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; frame-ancestors 'none'",
+  "web_accessible_resources": ["pageProvider.js", "phishing.html"]
 }

--- a/apps/extension/build/_raw/manifest/_base_v3.json
+++ b/apps/extension/build/_raw/manifest/_base_v3.json
@@ -43,12 +43,12 @@
 
   "web_accessible_resources": [
     {
-      "resources": ["pageProvider.js", "index.html"],
+      "resources": ["pageProvider.js", "phishing.html"],
       "matches": ["<all_urls>"]
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; frame-ancestors 'none'"
   },
   "side_panel": {
     "default_path": "sidepanel.html"

--- a/apps/extension/build/_raw/manifest/brave.json
+++ b/apps/extension/build/_raw/manifest/brave.json
@@ -1,7 +1,6 @@
 {
   "externally_connectable": {
-    "matches": ["https://unisat.io/*"],
-    "ids": ["*"]
+    "matches": ["https://unisat.io/*"]
   },
   "minimum_chrome_version": "66"
 }

--- a/apps/extension/build/_raw/manifest/chrome.json
+++ b/apps/extension/build/_raw/manifest/chrome.json
@@ -1,7 +1,6 @@
 {
   "externally_connectable": {
-    "matches": ["https://unisat.io/*"],
-    "ids": ["*"]
+    "matches": ["https://unisat.io/*"]
   },
   "minimum_chrome_version": "88"
 }

--- a/apps/extension/build/_raw/manifest/edge.json
+++ b/apps/extension/build/_raw/manifest/edge.json
@@ -1,7 +1,6 @@
 {
   "externally_connectable": {
-    "matches": ["https://unisat.io/*"],
-    "ids": ["*"]
+    "matches": ["https://unisat.io/*"]
   },
   "minimum_chrome_version": "66"
 }

--- a/apps/extension/build/_raw/phishing.html
+++ b/apps/extension/build/_raw/phishing.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Web site created using create-react-app" />
+    <link rel="manifest" href="/manifest.json" />
+
+    <title>UniSat Phishing Warning</title>
+  </head>
+
+  <body style="background-color: #070606">
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/apps/extension/build/paths.js
+++ b/apps/extension/build/paths.js
@@ -9,6 +9,7 @@ function getBrowserPaths(browser) {
     root: appRoot,
     src: rootResolve('src'),
     indexHtml: rootResolve('build/_raw/index.html'),
+    phishingHtml: rootResolve('build/_raw/phishing.html'),
     sidepanelHtml: rootResolve('build/_raw/sidepanel.html'),
     notificationHtml: rootResolve('build/_raw/notification.html'),
     backgroundHtml: rootResolve('src/background/background.html'),

--- a/apps/extension/build/webpack.common.config.js
+++ b/apps/extension/build/webpack.common.config.js
@@ -476,6 +476,12 @@ const config = (env) => {
       }),
       new HtmlWebpackPlugin({
         inject: true,
+        template: paths.phishingHtml,
+        chunks: ['ui'],
+        filename: 'phishing.html'
+      }),
+      new HtmlWebpackPlugin({
+        inject: true,
         template: paths.backgroundHtml,
         chunks: ['background'],
         filename: 'background.html'

--- a/apps/extension/src/_locales/en/messages.json
+++ b/apps/extension/src/_locales/en/messages.json
@@ -2075,6 +2075,12 @@
   "sighash_none_risk_title": {
     "message": "SIGHASH_NONE detected"
   },
+  "sighash_single_risk_description": {
+    "message": "SIGHASH_SINGLE binds only one output. Other outputs can be changed after signing, which can lead to unexpected fund movement. Review outputs carefully before signing."
+  },
+  "sighash_single_risk_title": {
+    "message": "SIGHASH_SINGLE detected"
+  },
   "sign": {
     "message": "Sign"
   },

--- a/apps/extension/src/background/runtime/messaging.ts
+++ b/apps/extension/src/background/runtime/messaging.ts
@@ -8,7 +8,7 @@ import {
   walletController
 } from '@unisat/wallet-background';
 import { BUS_EVENTS, MESSAGE_TYPE, PORT_CHANNELS } from '@unisat/wallet-shared';
-import { browserRuntimeOnConnect } from '../webapi/browser';
+import browser, { browserRuntimeOnConnect } from '../webapi/browser';
 export function initMessaging() {
   // for page provider
   browserRuntimeOnConnect((port) => {
@@ -16,8 +16,14 @@ export function initMessaging() {
 
     const pm = new PortMessage(port as any);
 
-    // UI ports
+    // UI ports — only accept connections from this extension
     if (['popup', 'notification', 'tab', 'sidepanel'].includes(portName)) {
+      const selfId = browser.runtime?.id;
+      if (port.sender?.id && selfId && port.sender.id !== selfId) {
+        port.disconnect();
+        return;
+      }
+
       // listen the message from UI
       pm.listen((data) => {
         if (!data?.type) return;

--- a/apps/extension/src/background/utils/encryptor.ts
+++ b/apps/extension/src/background/utils/encryptor.ts
@@ -1,13 +1,113 @@
-import * as browserPassworder from 'browser-passworder';
+/**
+ * Self-contained vault encryptor for the extension background.
+ * Avoids depending on a rebuilt @unisat/keyring-service lib artifact.
+ * Same algorithm as packages/keyring-service WebCryptoVaultEncryptor.
+ */
+const LEGACY_ITERATIONS = 10_000;
+const CURRENT_ITERATIONS = 600_000;
 
-// Production-ready encryptor using browser-passworder
+type VaultPayload = {
+  data: string;
+  iv: string;
+  salt: string;
+  iterations?: number;
+};
+
+function bufferToBase64(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary);
+}
+
+function base64ToBuffer(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function utf8ToBuffer(str: string): Uint8Array {
+  return new TextEncoder().encode(str);
+}
+
+function bufferToUtf8(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  return new TextDecoder().decode(bytes);
+}
+
+async function deriveAesKey(password: string, saltB64: string, iterations: number): Promise<CryptoKey> {
+  const passKey = await crypto.subtle.importKey(
+    'raw',
+    utf8ToBuffer(password) as BufferSource,
+    { name: 'PBKDF2' },
+    false,
+    ['deriveKey']
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: base64ToBuffer(saltB64) as BufferSource,
+      iterations,
+      hash: 'SHA-256'
+    },
+    passKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+async function decryptWithIterations(password: string, payload: VaultPayload, iterations: number): Promise<any> {
+  const key = await deriveAesKey(password, payload.salt, iterations);
+  const plain = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: base64ToBuffer(payload.iv) as BufferSource },
+    key,
+    base64ToBuffer(payload.data) as BufferSource
+  );
+  return JSON.parse(bufferToUtf8(plain));
+}
 
 async function encrypt(password: string, data: any): Promise<string> {
-  return await browserPassworder.encrypt(password, data);
+  const saltBytes = crypto.getRandomValues(new Uint8Array(32));
+  const salt = bufferToBase64(saltBytes);
+  const iv = crypto.getRandomValues(new Uint8Array(16));
+  const key = await deriveAesKey(password, salt, CURRENT_ITERATIONS);
+  const cipher = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    utf8ToBuffer(JSON.stringify(data)) as BufferSource
+  );
+  const payload: VaultPayload = {
+    data: bufferToBase64(cipher),
+    iv: bufferToBase64(iv),
+    salt,
+    iterations: CURRENT_ITERATIONS
+  };
+  return JSON.stringify(payload);
 }
 
 async function decrypt(password: string, encryptedData: string): Promise<any> {
-  return await browserPassworder.decrypt(password, encryptedData);
+  const payload = JSON.parse(encryptedData) as VaultPayload;
+  if (!payload?.data || !payload?.iv || !payload?.salt) {
+    throw new Error('Incorrect password');
+  }
+
+  const candidates =
+    typeof payload.iterations === 'number' ? [payload.iterations] : [CURRENT_ITERATIONS, LEGACY_ITERATIONS];
+
+  for (const iterations of candidates) {
+    try {
+      return await decryptWithIterations(password, payload, iterations);
+    } catch {
+      // try next
+    }
+  }
+  throw new Error('Incorrect password');
 }
 
 export const encryptor = {

--- a/apps/extension/src/ui/components/Iframe.tsx
+++ b/apps/extension/src/ui/components/Iframe.tsx
@@ -8,12 +8,15 @@ const Iframe = ({ preview, style, ref, onLoad }: IframeProps) => {
       <iframe
         onClick={(e) => e.preventDefault()}
         ref={ref}
-        style={Object.assign({}, { pointerEvents: 'auto' }, style)}
+        style={Object.assign({}, { pointerEvents: 'none' }, style)}
         src={preview}
         onLoad={onLoad}
-        sandbox="allow-scripts allow-same-origin allow-forms"
+        // Scripts allowed for HTML inscriptions; same-origin removed to reduce sandbox escape risk.
+        sandbox="allow-scripts"
         scrolling="no"
-        loading="lazy"></iframe>
+        loading="lazy"
+        referrerPolicy="no-referrer"
+      />
     ),
     [preview]
   );

--- a/apps/extension/src/ui/components/SignPsbtWithRisksPopover/index.tsx
+++ b/apps/extension/src/ui/components/SignPsbtWithRisksPopover/index.tsx
@@ -37,6 +37,11 @@ function getRiskContentKey(riskType: RiskType) {
         title: 'sighash_none_risk_title',
         description: 'sighash_none_risk_description'
       };
+    case RiskType.SIGHASH_SINGLE:
+      return {
+        title: 'sighash_single_risk_title',
+        description: 'sighash_single_risk_description'
+      };
     case RiskType.SCAMMER_ADDRESS:
       return {
         title: 'scammer_address_risk_title',

--- a/apps/extension/src/ui/pages/Account/CreateHDWalletScreen.tsx
+++ b/apps/extension/src/ui/pages/Account/CreateHDWalletScreen.tsx
@@ -35,7 +35,7 @@ export default function CreateHDWalletScreen() {
     isCustom: false,
     customHdPath: '',
     addressTypeIndex: 0,
-    wordsType: WordsType.WORDS_12
+    wordsType: WordsType.WORDS_24
   });
 
   const updateContextData = useCallback(

--- a/apps/extension/src/ui/pages/Account/createHDWalletComponents/Step1_Create.tsx
+++ b/apps/extension/src/ui/pages/Account/createHDWalletComponents/Step1_Create.tsx
@@ -1,11 +1,16 @@
 import { CheckboxChangeEvent } from 'antd/lib/checkbox';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
-import { Button, Card, Checkbox, Column, Grid, Row, Text } from '@/ui/components';
+import { Button, Card, Checkbox, Column, Grid, Radio, RadioGroup, Row, Text } from '@/ui/components';
 import { FooterButtonContainer } from '@/ui/components/FooterButtonContainer';
 import { ContextData, TabType, UpdateContextDataParams } from '@/ui/pages/Account/createHDWalletComponents/types';
 import { fontSizes } from '@/ui/theme/font';
+import { WordsType } from '@unisat/wallet-shared';
 import { useI18n, useWallet } from '@unisat/wallet-state';
+
+function wordsTypeToStrength(wordsType: WordsType): 128 | 256 {
+  return wordsType === WordsType.WORDS_24 ? 256 : 128;
+}
 
 export function Step1_Create({
   contextData,
@@ -15,19 +20,42 @@ export function Step1_Create({
   updateContextData: (params: UpdateContextDataParams) => void;
 }) {
   const [checked, setChecked] = useState(false);
+  const [generating, setGenerating] = useState(false);
   const { t } = useI18n();
   const wallet = useWallet();
 
-  const init = async () => {
-    const _mnemonics = await wallet.generatePreMnemonic();
-    updateContextData({
-      mnemonics: _mnemonics
-    });
-  };
+  const generate = useCallback(
+    async (wordsType: WordsType) => {
+      setGenerating(true);
+      setChecked(false);
+      try {
+        const strength = wordsTypeToStrength(wordsType);
+        const _mnemonics = await wallet.generatePreMnemonic(strength);
+        updateContextData({
+          mnemonics: _mnemonics,
+          wordsType,
+          step1CreateWordsCompleted: false
+        });
+      } finally {
+        setGenerating(false);
+      }
+    },
+    [updateContextData, wallet]
+  );
 
   useEffect(() => {
-    init();
+    if (!contextData.mnemonics) {
+      void generate(contextData.wordsType ?? WordsType.WORDS_24);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- initial generate only
   }, []);
+
+  const onSelectWordsType = async (wordsType: WordsType) => {
+    if (wordsType === contextData.wordsType && contextData.mnemonics) {
+      return;
+    }
+    await generate(wordsType);
+  };
 
   const onChange = (e: CheckboxChangeEvent) => {
     const val = e.target.checked;
@@ -41,11 +69,22 @@ export function Step1_Create({
     });
   };
 
-  const words = contextData.mnemonics.split(' ');
+  const words = contextData.mnemonics ? contextData.mnemonics.split(' ') : [];
   return (
     <Column gap="xl">
       <Text text={t('secret_recovery_phrase')} preset="title-bold" textCenter data-testid="mnemonic-title" />
       <Text text={t('this_phrase_is_the_only_way_to_recover_your_wallet')} color="warning" textCenter />
+
+      <Row justifyCenter>
+        <RadioGroup
+          onChange={(value) => {
+            void onSelectWordsType(value as WordsType);
+          }}
+          value={contextData.wordsType}>
+          <Radio value={WordsType.WORDS_12}>{t('mnemonics_12_words')}</Radio>
+          <Radio value={WordsType.WORDS_24}>{t('mnemonics_24_words')}</Radio>
+        </RadioGroup>
+      </Row>
 
       <Row justifyCenter>
         <Grid columns={2}>
@@ -69,7 +108,13 @@ export function Step1_Create({
       </Row>
 
       <FooterButtonContainer>
-        <Button disabled={!checked} text={t('continue')} preset="primary" onClick={btnClick} data-testid="mnemonic-continue-button" />
+        <Button
+          disabled={!checked || generating || words.length === 0}
+          text={t('continue')}
+          preset="primary"
+          onClick={btnClick}
+          data-testid="mnemonic-continue-button"
+        />
       </FooterButtonContainer>
     </Column>
   );

--- a/apps/extension/src/ui/pages/Phishing/PhishingScreen.tsx
+++ b/apps/extension/src/ui/pages/Phishing/PhishingScreen.tsx
@@ -1,8 +1,30 @@
 import { useSearchParams } from 'react-router-dom';
+import { useMemo } from 'react';
 
 import { useI18n } from '@unisat/wallet-state';
 
 import './PhishingScreen.css';
+
+/**
+ * Only allow http(s) navigation after phishing proceed.
+ * Blocks chrome-extension:, javascript:, data:, etc. (open-redirect / WAR pivot).
+ */
+function sanitizeProceedHref(href: string | null, hostname: string | null): string | null {
+  if (href) {
+    try {
+      const u = new URL(href);
+      if (u.protocol === 'http:' || u.protocol === 'https:') {
+        return u.toString();
+      }
+    } catch {
+      // fall through
+    }
+  }
+  if (hostname && /^[a-z0-9.-]+$/i.test(hostname)) {
+    return `https://${hostname}`;
+  }
+  return null;
+}
 
 const PhishingScreen = () => {
   const [searchParams] = useSearchParams();
@@ -10,26 +32,36 @@ const PhishingScreen = () => {
   const href = searchParams.get('href');
   const { t } = useI18n();
 
+  const isFramed = useMemo(() => {
+    try {
+      return window.top !== window;
+    } catch {
+      // cross-origin frame access denied ⇒ we are framed
+      return true;
+    }
+  }, []);
+
+  const safeHref = useMemo(() => sanitizeProceedHref(href, hostname), [href, hostname]);
+
   const handleProceed = async () => {
-    // Send message to background to proceed (one-time bypass, not adding to whitelist)
+    if (isFramed) {
+      return;
+    }
+    if (!hostname || !safeHref) {
+      return;
+    }
+
     await chrome.runtime.sendMessage({
       type: 'SKIP_PHISHING_PROTECTION',
       hostname
     });
 
-    // Redirect to the original URL if available
-    if (href) {
-      window.location.href = href;
-    } else {
-      // Fallback to hostname if full URL is not available
-      window.location.href = `https://${hostname}`;
-    }
+    window.location.href = safeHref;
   };
 
   return (
     <div className="phishing-container">
       <div className="phishing-content">
-        {/* Logo & Warning */}
         <div className="phishing-header">
           <img src={chrome.runtime.getURL('/images/logo/wallet-logo.png')} alt="UniSat" className="phishing-logo" />
           <div className="phishing-divider" />
@@ -47,13 +79,11 @@ const PhishingScreen = () => {
           </div>
         </div>
 
-        {/* Title & Domain */}
         <div className="phishing-title-section">
           <h1>{t('danger_potential_phishing_website_detected')}</h1>
           <p className="phishing-domain">{hostname}</p>
         </div>
 
-        {/* Warning Message */}
         <div className="phishing-warning-box">
           <p>{t('this_website_has_been_identified_as_malicious_by_unisat_and_may')}</p>
           <ul>
@@ -63,7 +93,6 @@ const PhishingScreen = () => {
           </ul>
         </div>
 
-        {/* Actions */}
         <div className="phishing-actions">
           <a
             href="https://github.com/unisat-wallet/phishing-detect/issues/new"
@@ -72,12 +101,22 @@ const PhishingScreen = () => {
             className="phishing-report-link">
             {t('think_this_is_a_false_positive_click_here_to_report_an_issue')}
           </a>
-          <p className="phishing-proceed-text">
-            {t('if_you_insist_on_continuing_proceed_at_your_own_risk')}
-            <button onClick={handleProceed} className="phishing-proceed-button">
-              {t('continue_to')} {hostname}
-            </button>
-          </p>
+          {isFramed ? (
+            <p className="phishing-proceed-text">
+              This warning must be opened as a top-level tab (not inside a page iframe). Close this embed and revisit
+              the site so UniSat can show a full-page warning.
+            </p>
+          ) : (
+            <p className="phishing-proceed-text">
+              {t('if_you_insist_on_continuing_proceed_at_your_own_risk')}
+              <button
+                onClick={handleProceed}
+                className="phishing-proceed-button"
+                disabled={!safeHref || !hostname}>
+                {t('continue_to')} {hostname}
+              </button>
+            </p>
+          )}
         </div>
       </div>
     </div>

--- a/packages/keyring-service/src/encryptor/browser-encryptor.ts
+++ b/packages/keyring-service/src/encryptor/browser-encryptor.ts
@@ -1,15 +1,19 @@
 import { Encryptor } from '../types'
+import { WebCryptoVaultEncryptor } from './webcrypto-vault-encryptor'
 
-// @ts-ignore
-import * as browserPassworder from 'browser-passworder'
-
-// Production-ready encryptor using browser-passworder
+/**
+ * Production encryptor.
+ * Historically wrapped browser-passworder (PBKDF2 10k).
+ * Now uses WebCryptoVaultEncryptor (PBKDF2 600k) with legacy 10k decrypt fallback.
+ */
 export class BrowserPassworderEncryptor implements Encryptor {
+  private readonly impl = new WebCryptoVaultEncryptor()
+
   async encrypt(password: string, data: any): Promise<string> {
-    return await browserPassworder.encrypt(password, data)
+    return this.impl.encrypt(password, data)
   }
 
   async decrypt(password: string, encryptedData: string): Promise<any> {
-    return await browserPassworder.decrypt(password, encryptedData)
+    return this.impl.decrypt(password, encryptedData)
   }
 }

--- a/packages/keyring-service/src/encryptor/webcrypto-vault-encryptor.ts
+++ b/packages/keyring-service/src/encryptor/webcrypto-vault-encryptor.ts
@@ -1,0 +1,131 @@
+/**
+ * Production vault encryptor (WebCrypto).
+ *
+ * - Encrypt: PBKDF2-SHA256 @ 600_000 iterations + AES-GCM (OWASP-aligned)
+ * - Decrypt: uses payload.iterations when present; otherwise tries 600k then legacy 10k
+ *   so existing UniSat vaults (browser-passworder @ 10k) still unlock, then get re-encrypted
+ *   on the next persist.
+ */
+import { Encryptor } from '../types'
+
+const LEGACY_ITERATIONS = 10_000
+const CURRENT_ITERATIONS = 600_000
+
+type VaultPayload = {
+  data: string
+  iv: string
+  salt: string
+  iterations?: number
+}
+
+function bufferToBase64(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!)
+  }
+  return btoa(binary)
+}
+
+function base64ToBuffer(b64: string): Uint8Array {
+  const binary = atob(b64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+function utf8ToBuffer(str: string): Uint8Array {
+  return new TextEncoder().encode(str)
+}
+
+function bufferToUtf8(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf)
+  return new TextDecoder().decode(bytes)
+}
+
+async function deriveAesKey(password: string, saltB64: string, iterations: number): Promise<CryptoKey> {
+  const passKey = await crypto.subtle.importKey(
+    'raw',
+    utf8ToBuffer(password) as BufferSource,
+    { name: 'PBKDF2' },
+    false,
+    ['deriveKey']
+  )
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: base64ToBuffer(saltB64) as BufferSource,
+      iterations,
+      hash: 'SHA-256',
+    },
+    passKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  )
+}
+
+async function decryptWithIterations(
+  password: string,
+  payload: VaultPayload,
+  iterations: number
+): Promise<any> {
+  const key = await deriveAesKey(password, payload.salt, iterations)
+  const plain = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: base64ToBuffer(payload.iv) as BufferSource },
+    key,
+    base64ToBuffer(payload.data) as BufferSource
+  )
+  return JSON.parse(bufferToUtf8(plain))
+}
+
+export class WebCryptoVaultEncryptor implements Encryptor {
+  readonly currentIterations = CURRENT_ITERATIONS
+  readonly legacyIterations = LEGACY_ITERATIONS
+
+  async encrypt(password: string, data: any): Promise<string> {
+    const saltBytes = crypto.getRandomValues(new Uint8Array(32))
+    const salt = bufferToBase64(saltBytes)
+    const iv = crypto.getRandomValues(new Uint8Array(16))
+    const key = await deriveAesKey(password, salt, CURRENT_ITERATIONS)
+    const cipher = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      utf8ToBuffer(JSON.stringify(data)) as BufferSource
+    )
+    const payload: VaultPayload = {
+      data: bufferToBase64(cipher),
+      iv: bufferToBase64(iv),
+      salt,
+      iterations: CURRENT_ITERATIONS,
+    }
+    return JSON.stringify(payload)
+  }
+
+  async decrypt(password: string, encryptedData: string): Promise<any> {
+    const payload = JSON.parse(encryptedData) as VaultPayload
+    if (!payload?.data || !payload?.iv || !payload?.salt) {
+      throw new Error('Incorrect password')
+    }
+
+    const candidates =
+      typeof payload.iterations === 'number'
+        ? [payload.iterations]
+        : [CURRENT_ITERATIONS, LEGACY_ITERATIONS]
+
+    let lastError: unknown
+    for (const iterations of candidates) {
+      try {
+        return await decryptWithIterations(password, payload, iterations)
+      } catch (e) {
+        lastError = e
+      }
+    }
+    // Match browser-passworder UX
+    throw new Error('Incorrect password')
+  }
+}
+
+export const webCryptoVaultEncryptor = new WebCryptoVaultEncryptor()

--- a/packages/keyring-service/src/index.ts
+++ b/packages/keyring-service/src/index.ts
@@ -6,6 +6,7 @@ export { SimpleKeyring, HdKeyring, KeystoneKeyring, ColdWalletKeyring } from './
 
 // encryptor
 export { BrowserPassworderEncryptor } from './encryptor/browser-encryptor'
+export { WebCryptoVaultEncryptor, webCryptoVaultEncryptor } from './encryptor/webcrypto-vault-encryptor'
 export { SimpleEncryptor } from './encryptor/simple-encryptor'
 
 export * from './types'

--- a/packages/keyring-service/src/keyring-service.ts
+++ b/packages/keyring-service/src/keyring-service.ts
@@ -338,15 +338,15 @@ export class KeyringService extends EventEmitter {
     return keyring
   }
 
-  generateMnemonic = (): string => {
-    return bip39.generateMnemonic(128)
+  generateMnemonic = (strength: 128 | 256 = 128): string => {
+    return bip39.generateMnemonic(strength)
   }
 
-  generatePreMnemonic = async (): Promise<string> => {
+  generatePreMnemonic = async (strength: 128 | 256 = 128): Promise<string> => {
     if (!this.password) {
       throw new Error(this.t('you_need_to_unlock_wallet_first'))
     }
-    const mnemonic = this.generateMnemonic()
+    const mnemonic = this.generateMnemonic(strength)
 
     const preMnemonics = await this.encryptor.encrypt(this.password, mnemonic)
     this.memStore.updateState({ preMnemonics })

--- a/packages/keyring-service/tsconfig.json
+++ b/packages/keyring-service/tsconfig.json
@@ -18,7 +18,8 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": false
+    "noEmit": false,
+    "lib": ["ES2020", "DOM"]
   },
   "include": [
     "src/**/*"

--- a/packages/tx-helpers/src/decode-psbt.ts
+++ b/packages/tx-helpers/src/decode-psbt.ts
@@ -11,6 +11,12 @@ function isDangerousSighashType(sighashType?: number): boolean {
   return outputType === bitcoin.Transaction.SIGHASH_NONE
 }
 
+function isSighashSingleType(sighashType?: number): boolean {
+  if (typeof sighashType !== 'number') return false
+  const outputType = sighashType & bitcoin.Transaction.SIGHASH_OUTPUT_MASK
+  return outputType === bitcoin.Transaction.SIGHASH_SINGLE
+}
+
 interface InputInfo {
   txid: string
   vout: number
@@ -323,6 +329,16 @@ export class PsbtDecoder {
         level: 'danger',
         title: 'sighash_none_risk_title',
         desc: 'sighash_none_risk_description',
+      })
+    }
+
+    const foundSighashSingle = this._psbt.data.inputs.some(v => isSighashSingleType(v.sighashType))
+    if (foundSighashSingle) {
+      this.risks.push({
+        type: RiskType.SIGHASH_SINGLE,
+        level: 'warning',
+        title: 'sighash_single_risk_title',
+        desc: 'sighash_single_risk_description',
       })
     }
   }

--- a/packages/tx-helpers/test/decode-psbt.test.ts
+++ b/packages/tx-helpers/test/decode-psbt.test.ts
@@ -37,15 +37,16 @@ describe('decode psbt sighash risk detection', () => {
     expect(dangerous.risks.some(r => r.type === RiskType.SIGHASH_NONE)).toBe(true)
   })
 
-  it('does not flag SIGHASH_SINGLE | ANYONECANPAY as dangerous', async () => {
-    const safe = await decodeWithSighashType(
+  it('flags SIGHASH_SINGLE | ANYONECANPAY as warning', async () => {
+    const single = await decodeWithSighashType(
       bitcoin.Transaction.SIGHASH_SINGLE | bitcoin.Transaction.SIGHASH_ANYONECANPAY
     )
-    expect(safe.risks.some(r => r.type === RiskType.SIGHASH_NONE)).toBe(false)
+    expect(single.risks.some(r => r.type === RiskType.SIGHASH_SINGLE)).toBe(true)
   })
 
   it('does not flag SIGHASH_ALL as dangerous', async () => {
     const safe = await decodeWithSighashType(bitcoin.Transaction.SIGHASH_ALL)
     expect(safe.risks.some(r => r.type === RiskType.SIGHASH_NONE)).toBe(false)
+    expect(safe.risks.some(r => r.type === RiskType.SIGHASH_SINGLE)).toBe(false)
   })
 })

--- a/packages/wallet-background/src/controllers/phishing.ts
+++ b/packages/wallet-background/src/controllers/phishing.ts
@@ -89,6 +89,13 @@ class PhishingController {
             return false
           }
 
+          // Only extension pages may whitelist (not arbitrary extension contexts without URL).
+          const extensionOrigin = chrome.runtime.getURL('')
+          if (!sender.url || !sender.url.startsWith(extensionOrigin)) {
+            sendResponse({ error: 'Unauthorized' })
+            return false
+          }
+
           phishingService.addToWhitelist(message.hostname)
           sendResponse({ success: true })
           return false
@@ -117,7 +124,10 @@ class PhishingController {
             const url = new URL(message.url)
 
             // Skip checks for phishing warning page URL
-            if (message.url.includes(chrome.runtime.getURL('index.html#/phishing'))) {
+            if (
+              message.url.includes(chrome.runtime.getURL('phishing.html#/phishing')) ||
+              message.url.includes(chrome.runtime.getURL('index.html#/phishing'))
+            ) {
               sendResponse({ isPhishing: false, skipped: true })
               return false
             }
@@ -160,7 +170,7 @@ class PhishingController {
       const currentUrl = tab.url || ''
 
       // If already on warning page, don't redirect again
-      if (currentUrl.includes('index.html#/phishing')) {
+      if (currentUrl.includes('phishing.html#/phishing') || currentUrl.includes('index.html#/phishing')) {
         return
       }
 
@@ -170,7 +180,7 @@ class PhishingController {
         timestamp: Date.now().toString(), // Add timestamp to prevent caching
       })
 
-      const redirectUrl = chrome.runtime.getURL(`index.html#/phishing?${params}`)
+      const redirectUrl = chrome.runtime.getURL(`phishing.html#/phishing?${params}`)
       await chrome.tabs.update(tabId, { url: redirectUrl, active: true })
     } catch (error) {
       log.error('[Phishing] Failed to redirect tab:', error)
@@ -283,7 +293,7 @@ class PhishingController {
           type: chrome.declarativeNetRequest.RuleActionType.REDIRECT,
           redirect: {
             url: chrome.runtime.getURL(
-              `index.html#/phishing?hostname=${encodeURIComponent(domain)}&timestamp=${Date.now()}`
+              `phishing.html#/phishing?hostname=${encodeURIComponent(domain)}&timestamp=${Date.now()}`
             ),
           },
         },

--- a/packages/wallet-background/src/controllers/wallet.ts
+++ b/packages/wallet-background/src/controllers/wallet.ts
@@ -386,8 +386,8 @@ export class WalletController extends BaseController {
   }
 
   getPreMnemonics = () => keyringService.getPreMnemonics()
-  generatePreMnemonic = async () => {
-    return await keyringService.generatePreMnemonic()
+  generatePreMnemonic = async (strength: 128 | 256 = 128) => {
+    return await keyringService.generatePreMnemonic(strength)
   }
   removePreMnemonics = () => keyringService.removePreMnemonics()
   createKeyringWithMnemonics = async (

--- a/packages/wallet-shared/src/types/decode-tx.ts
+++ b/packages/wallet-shared/src/types/decode-tx.ts
@@ -24,6 +24,7 @@ export enum RiskType {
   ALKANES_BURNING,
   ALKANES_MULTIPLE_ASSETS,
   UTXO_INDEXING,
+  SIGHASH_SINGLE,
 }
 
 export interface Risk {

--- a/packages/wallet-state/src/context/WalletContext.tsx
+++ b/packages/wallet-state/src/context/WalletContext.tsx
@@ -152,7 +152,7 @@ export interface WalletController {
     alianName?: string
   ): Promise<Account[]>
   getPreMnemonics(): Promise<any>
-  generatePreMnemonic(): Promise<string>
+  generatePreMnemonic(strength?: 128 | 256): Promise<string>
   removePreMnemonics(): void
   createKeyringWithMnemonics(
     mnemonic: string,


### PR DESCRIPTION
# Security hardening (extension v1.7.17)

Independent review against UniSat Wallet `extension/v1.7.17` (`2b1b16c`).

This PR hardens real, reproducible issues found in the Chrome extension path. It does **not** claim a remote silent siphon / auto-sign critical.

## Summary

1. **Phishing UI clickjacking / WAR (High)**  
   - Remove `index.html` from `web_accessible_resources`  
   - Dedicated `phishing.html` (+ `pageProvider.js` only in WAR)  
   - CSP `frame-ancestors 'none'`  
   - Proceed blocked when framed (`window.top !== window`)  
   - Proceed `href` allowlist: **http(s) only** (blocks `chrome-extension:` / `javascript:` pivots)  
   - `SKIP_PHISHING_PROTECTION` requires `sender.url` under the extension origin  

2. **Vault KDF (Medium)**  
   - Replace browser-passworder default path with WebCrypto **PBKDF2-SHA256 @ 600_000** + AES-GCM  
   - Decrypt fallback: payload `iterations` → else try 600k then legacy **10k** so existing vaults still unlock  
   - Next persist re-encrypts at 600k  

3. **Mnemonic length on create**  
   - Create flow now offers **12 / 24** (import already did)  
   - Default for new wallets: **24 words (256-bit BIP39)**  
   - Entropy via `bip39.generateMnemonic(strength)` → `@noble/hashes` `randomBytes` → `crypto.getRandomValues`  

4. **`externally_connectable`**  
   - Remove `"ids": ["*"]` from Chrome/Edge/Brave manifests (keep `https://unisat.io/*`)  

5. **UI port sender check**  
   - Disconnect UI-named ports when `sender.id !== runtime.id`  

6. **Inscription iframe (Medium)**  
   - `sandbox="allow-scripts"` only (drop `allow-same-origin` / `allow-forms`)  
   - `pointer-events: none`, `referrerPolicy=no-referrer`  

7. **PSBT local risk (Medium)**  
   - Flag `SIGHASH_SINGLE` as warning  
   - Wire UI copy (`sighash_single_risk_*`) in `SignPsbtWithRisksPopover`  

## Test plan

- [x] Fresh create: 12 and 24 word radios; default 24; home screen after create  
- [x] Legacy-shaped 10k vault ciphertext decrypts; re-encrypt stamps `iterations: 600000`  
- [x] Real `@metamask/browser-passworder`-compatible 10k blob decrypts via fallback  
- [x] Phishing page: https Continue works top-level; `chrome-extension:` href does not pivot  
- [x] Hostile iframe of `phishing.html` → browser “refused to connect” (`frame-ancestors`)  
- [x] `window.unisat` injects; no page-facing `generateMnemonic` / `exportPrivateKey`  
- [x] `tx-helpers` unit tests including `SIGHASH_SINGLE`  
- [ ] Maintainer: existing production vault unlock → lock → confirm 600k persist  
- [ ] Maintainer: SignPsbt with `SIGHASH_SINGLE` shows localized warning  
- [ ] Maintainer: Chrome MV3 store/pro build (`gulp build`) smoke on provider injection  

## Build note

Local verification used Chrome MV3 webpack output. Please run the repo’s normal `gulp build --env=pro --browser=chrome --manifest=mv3` smoke (popup + `window.unisat` on a https page) before store publish.

## Out of scope / not claimed

- Remote silent siphon / auto-sign bypass (not found on this pin)  
- “Broken BIP39 CSPRNG” (uses `getRandomValues`)  
- Mobile app (separate surface; not covered by this extension PR)  
