### PR TITLE
security(extension): phishing WAR, frame-ancestors, proceed hardening

### DIFF
--- a/apps/extension/build/_raw/manifest/_base_v2.json
+++ b/apps/extension/build/_raw/manifest/_base_v2.json
@@ -40,6 +40,6 @@
       "all_frames": true
     }
   ],
-  "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",
-  "web_accessible_resources": ["pageProvider.js", "index.html"]
+  "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; frame-ancestors 'none'",
+  "web_accessible_resources": ["pageProvider.js", "phishing.html"]
 }

--- a/apps/extension/build/_raw/manifest/_base_v3.json
+++ b/apps/extension/build/_raw/manifest/_base_v3.json
@@ -43,12 +43,12 @@
 
   "web_accessible_resources": [
     {
-      "resources": ["pageProvider.js", "index.html"],
+      "resources": ["pageProvider.js", "phishing.html"],
       "matches": ["<all_urls>"]
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; frame-ancestors 'none'"
   },
   "side_panel": {
     "default_path": "sidepanel.html"

--- a/apps/extension/build/_raw/phishing.html
+++ b/apps/extension/build/_raw/phishing.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Web site created using create-react-app" />
+    <link rel="manifest" href="/manifest.json" />
+
+    <title>UniSat Phishing Warning</title>
+  </head>
+
+  <body style="background-color: #070606">
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/apps/extension/build/paths.js
+++ b/apps/extension/build/paths.js
@@ -9,6 +9,7 @@ function getBrowserPaths(browser) {
     root: appRoot,
     src: rootResolve('src'),
     indexHtml: rootResolve('build/_raw/index.html'),
+    phishingHtml: rootResolve('build/_raw/phishing.html'),
     sidepanelHtml: rootResolve('build/_raw/sidepanel.html'),
     notificationHtml: rootResolve('build/_raw/notification.html'),
     backgroundHtml: rootResolve('src/background/background.html'),

--- a/apps/extension/build/webpack.common.config.js
+++ b/apps/extension/build/webpack.common.config.js
@@ -476,6 +476,12 @@ const config = (env) => {
       }),
       new HtmlWebpackPlugin({
         inject: true,
+        template: paths.phishingHtml,
+        chunks: ['ui'],
+        filename: 'phishing.html'
+      }),
+      new HtmlWebpackPlugin({
+        inject: true,
         template: paths.backgroundHtml,
         chunks: ['background'],
         filename: 'background.html'

--- a/apps/extension/src/ui/pages/Phishing/PhishingScreen.tsx
+++ b/apps/extension/src/ui/pages/Phishing/PhishingScreen.tsx
@@ -1,8 +1,30 @@
 import { useSearchParams } from 'react-router-dom';
+import { useMemo } from 'react';
 
 import { useI18n } from '@unisat/wallet-state';
 
 import './PhishingScreen.css';
+
+/**
+ * Only allow http(s) navigation after phishing proceed.
+ * Blocks chrome-extension:, javascript:, data:, etc. (open-redirect / WAR pivot).
+ */
+function sanitizeProceedHref(href: string | null, hostname: string | null): string | null {
+  if (href) {
+    try {
+      const u = new URL(href);
+      if (u.protocol === 'http:' || u.protocol === 'https:') {
+        return u.toString();
+      }
+    } catch {
+      // fall through
+    }
+  }
+  if (hostname && /^[a-z0-9.-]+$/i.test(hostname)) {
+    return `https://${hostname}`;
+  }
+  return null;
+}
 
 const PhishingScreen = () => {
   const [searchParams] = useSearchParams();
@@ -10,26 +32,36 @@ const PhishingScreen = () => {
   const href = searchParams.get('href');
   const { t } = useI18n();
 
+  const isFramed = useMemo(() => {
+    try {
+      return window.top !== window;
+    } catch {
+      // cross-origin frame access denied ⇒ we are framed
+      return true;
+    }
+  }, []);
+
+  const safeHref = useMemo(() => sanitizeProceedHref(href, hostname), [href, hostname]);
+
   const handleProceed = async () => {
-    // Send message to background to proceed (one-time bypass, not adding to whitelist)
+    if (isFramed) {
+      return;
+    }
+    if (!hostname || !safeHref) {
+      return;
+    }
+
     await chrome.runtime.sendMessage({
       type: 'SKIP_PHISHING_PROTECTION',
       hostname
     });
 
-    // Redirect to the original URL if available
-    if (href) {
-      window.location.href = href;
-    } else {
-      // Fallback to hostname if full URL is not available
-      window.location.href = `https://${hostname}`;
-    }
+    window.location.href = safeHref;
   };
 
   return (
     <div className="phishing-container">
       <div className="phishing-content">
-        {/* Logo & Warning */}
         <div className="phishing-header">
           <img src={chrome.runtime.getURL('/images/logo/wallet-logo.png')} alt="UniSat" className="phishing-logo" />
           <div className="phishing-divider" />
@@ -47,13 +79,11 @@ const PhishingScreen = () => {
           </div>
         </div>
 
-        {/* Title & Domain */}
         <div className="phishing-title-section">
           <h1>{t('danger_potential_phishing_website_detected')}</h1>
           <p className="phishing-domain">{hostname}</p>
         </div>
 
-        {/* Warning Message */}
         <div className="phishing-warning-box">
           <p>{t('this_website_has_been_identified_as_malicious_by_unisat_and_may')}</p>
           <ul>
@@ -63,7 +93,6 @@ const PhishingScreen = () => {
           </ul>
         </div>
 
-        {/* Actions */}
         <div className="phishing-actions">
           <a
             href="https://github.com/unisat-wallet/phishing-detect/issues/new"
@@ -72,12 +101,22 @@ const PhishingScreen = () => {
             className="phishing-report-link">
             {t('think_this_is_a_false_positive_click_here_to_report_an_issue')}
           </a>
-          <p className="phishing-proceed-text">
-            {t('if_you_insist_on_continuing_proceed_at_your_own_risk')}
-            <button onClick={handleProceed} className="phishing-proceed-button">
-              {t('continue_to')} {hostname}
-            </button>
-          </p>
+          {isFramed ? (
+            <p className="phishing-proceed-text">
+              This warning must be opened as a top-level tab (not inside a page iframe). Close this embed and revisit
+              the site so UniSat can show a full-page warning.
+            </p>
+          ) : (
+            <p className="phishing-proceed-text">
+              {t('if_you_insist_on_continuing_proceed_at_your_own_risk')}
+              <button
+                onClick={handleProceed}
+                className="phishing-proceed-button"
+                disabled={!safeHref || !hostname}>
+                {t('continue_to')} {hostname}
+              </button>
+            </p>
+          )}
         </div>
       </div>
     </div>

--- a/packages/wallet-background/src/controllers/phishing.ts
+++ b/packages/wallet-background/src/controllers/phishing.ts
@@ -89,6 +89,13 @@ class PhishingController {
             return false
           }
 
+          // Only extension pages may whitelist (not arbitrary extension contexts without URL).
+          const extensionOrigin = chrome.runtime.getURL('')
+          if (!sender.url || !sender.url.startsWith(extensionOrigin)) {
+            sendResponse({ error: 'Unauthorized' })
+            return false
+          }
+
           phishingService.addToWhitelist(message.hostname)
           sendResponse({ success: true })
           return false
@@ -117,7 +124,10 @@ class PhishingController {
             const url = new URL(message.url)
 
             // Skip checks for phishing warning page URL
-            if (message.url.includes(chrome.runtime.getURL('index.html#/phishing'))) {
+            if (
+              message.url.includes(chrome.runtime.getURL('phishing.html#/phishing')) ||
+              message.url.includes(chrome.runtime.getURL('index.html#/phishing'))
+            ) {
               sendResponse({ isPhishing: false, skipped: true })
               return false
             }
@@ -160,7 +170,7 @@ class PhishingController {
       const currentUrl = tab.url || ''
 
       // If already on warning page, don't redirect again
-      if (currentUrl.includes('index.html#/phishing')) {
+      if (currentUrl.includes('phishing.html#/phishing') || currentUrl.includes('index.html#/phishing')) {
         return
       }
 
@@ -170,7 +180,7 @@ class PhishingController {
         timestamp: Date.now().toString(), // Add timestamp to prevent caching
       })
 
-      const redirectUrl = chrome.runtime.getURL(`index.html#/phishing?${params}`)
+      const redirectUrl = chrome.runtime.getURL(`phishing.html#/phishing?${params}`)
       await chrome.tabs.update(tabId, { url: redirectUrl, active: true })
     } catch (error) {
       log.error('[Phishing] Failed to redirect tab:', error)
@@ -283,7 +293,7 @@ class PhishingController {
           type: chrome.declarativeNetRequest.RuleActionType.REDIRECT,
           redirect: {
             url: chrome.runtime.getURL(
-              `index.html#/phishing?hostname=${encodeURIComponent(domain)}&timestamp=${Date.now()}`
+              `phishing.html#/phishing?hostname=${encodeURIComponent(domain)}&timestamp=${Date.now()}`
             ),
           },
         },


### PR DESCRIPTION
Remove index.html from web_accessible_resources, serve dedicated phishing.html, add frame-ancestors 'none', block framed proceed, and allowlist http(s) hrefs.

## Summary
- Remove `index.html` from `web_accessible_resources`; keep `pageProvider.js` + dedicated `phishing.html`
- CSP `frame-ancestors 'none'`
- Block phishing proceed when framed (`window.top !== window`)
- Proceed `href` allowlist: http(s) only
- `SKIP_PHISHING_PROTECTION` requires `sender.url` under extension origin

Split from #8 per maintainer request for focused review.

## Test plan (Already done locally, mark X as you confirm)

- [ ] Hostile iframe of `phishing.html` → browser “refused to connect”
- [ ] Top-level phishing Continue with https works
- [ ] `chrome-extension:` / `javascript:` href does not pivot
- [ ] Normal popup / notification still loads

## Related
Supersedes part of #8 (phishing/WAR only).

