### PR TITLE
security(extension): drop externally_connectable ids * and check UI port sender

### DIFF
--- a/apps/extension/build/_raw/manifest/brave.json
+++ b/apps/extension/build/_raw/manifest/brave.json
@@ -1,7 +1,6 @@
 {
   "externally_connectable": {
-    "matches": ["https://unisat.io/*"],
-    "ids": ["*"]
+    "matches": ["https://unisat.io/*"]
   },
   "minimum_chrome_version": "66"
 }

--- a/apps/extension/build/_raw/manifest/chrome.json
+++ b/apps/extension/build/_raw/manifest/chrome.json
@@ -1,7 +1,6 @@
 {
   "externally_connectable": {
-    "matches": ["https://unisat.io/*"],
-    "ids": ["*"]
+    "matches": ["https://unisat.io/*"]
   },
   "minimum_chrome_version": "88"
 }

--- a/apps/extension/build/_raw/manifest/edge.json
+++ b/apps/extension/build/_raw/manifest/edge.json
@@ -1,7 +1,6 @@
 {
   "externally_connectable": {
-    "matches": ["https://unisat.io/*"],
-    "ids": ["*"]
+    "matches": ["https://unisat.io/*"]
   },
   "minimum_chrome_version": "66"
 }

--- a/apps/extension/src/background/runtime/messaging.ts
+++ b/apps/extension/src/background/runtime/messaging.ts
@@ -8,7 +8,7 @@ import {
   walletController
 } from '@unisat/wallet-background';
 import { BUS_EVENTS, MESSAGE_TYPE, PORT_CHANNELS } from '@unisat/wallet-shared';
-import { browserRuntimeOnConnect } from '../webapi/browser';
+import browser, { browserRuntimeOnConnect } from '../webapi/browser';
 export function initMessaging() {
   // for page provider
   browserRuntimeOnConnect((port) => {
@@ -16,8 +16,14 @@ export function initMessaging() {
 
     const pm = new PortMessage(port as any);
 
-    // UI ports
+    // UI ports — only accept connections from this extension
     if (['popup', 'notification', 'tab', 'sidepanel'].includes(portName)) {
+      const selfId = browser.runtime?.id;
+      if (port.sender?.id && selfId && port.sender.id !== selfId) {
+        port.disconnect();
+        return;
+      }
+
       // listen the message from UI
       pm.listen((data) => {
         if (!data?.type) return;


### PR DESCRIPTION
## Summary
- Remove `externally_connectable.ids: ["*"]` from Chrome/Edge/Brave manifests
- Keep `matches: ["https://unisat.io/*"]`
- Disconnect UI-named ports when `sender.id !== chrome.runtime.id`

Reduces latent cross-extension connect surface; no change to normal popup/content-script messaging.

## Test plan  (Already done locally, mark X as you confirm)
- [ ] Extension still loads; popup UI port works
- [ ] `window.unisat` still injects on https pages
- [ ] Manifest `externally_connectable` has no `ids: ["*"]`
- [ ] Foreign-extension connect to UI port name is rejected/disconnected (if tested)