### PR TITLE
security(extension): tighten inscription iframe sandbox

### DIFF
--- a/apps/extension/src/ui/components/Iframe.tsx
+++ b/apps/extension/src/ui/components/Iframe.tsx
@@ -8,12 +8,15 @@ const Iframe = ({ preview, style, ref, onLoad }: IframeProps) => {
       <iframe
         onClick={(e) => e.preventDefault()}
         ref={ref}
-        style={Object.assign({}, { pointerEvents: 'auto' }, style)}
+        style={Object.assign({}, { pointerEvents: 'none' }, style)}
         src={preview}
         onLoad={onLoad}
-        sandbox="allow-scripts allow-same-origin allow-forms"
+        // Scripts allowed for HTML inscriptions; same-origin removed to reduce sandbox escape risk.
+        sandbox="allow-scripts"
         scrolling="no"
-        loading="lazy"></iframe>
+        loading="lazy"
+        referrerPolicy="no-referrer"
+      />
     ),
     [preview]
   );


### PR DESCRIPTION
Drop allow-same-origin/allow-forms; keep allow-scripts; no-referrer + pointer-events none.

Mainly debatable. as can be softer. Keep sandbox="allow-scripts" (drop same-origin/forms) — main security win recommendation