### PR TITLE
security(extension): flag SIGHASH_SINGLE in PSBT risk UI

### DIFF
--- a/apps/extension/src/_locales/en/messages.json
+++ b/apps/extension/src/_locales/en/messages.json
@@ -2075,6 +2075,12 @@
   "sighash_none_risk_title": {
     "message": "SIGHASH_NONE detected"
   },
+  "sighash_single_risk_description": {
+    "message": "SIGHASH_SINGLE binds only one output. Other outputs can be changed after signing, which can lead to unexpected fund movement. Review outputs carefully before signing."
+  },
+  "sighash_single_risk_title": {
+    "message": "SIGHASH_SINGLE detected"
+  },
   "sign": {
     "message": "Sign"
   },

--- a/apps/extension/src/ui/components/SignPsbtWithRisksPopover/index.tsx
+++ b/apps/extension/src/ui/components/SignPsbtWithRisksPopover/index.tsx
@@ -37,6 +37,11 @@ function getRiskContentKey(riskType: RiskType) {
         title: 'sighash_none_risk_title',
         description: 'sighash_none_risk_description'
       };
+    case RiskType.SIGHASH_SINGLE:
+      return {
+        title: 'sighash_single_risk_title',
+        description: 'sighash_single_risk_description'
+      };
     case RiskType.SCAMMER_ADDRESS:
       return {
         title: 'scammer_address_risk_title',

--- a/packages/tx-helpers/src/decode-psbt.ts
+++ b/packages/tx-helpers/src/decode-psbt.ts
@@ -11,6 +11,12 @@ function isDangerousSighashType(sighashType?: number): boolean {
   return outputType === bitcoin.Transaction.SIGHASH_NONE
 }
 
+function isSighashSingleType(sighashType?: number): boolean {
+  if (typeof sighashType !== 'number') return false
+  const outputType = sighashType & bitcoin.Transaction.SIGHASH_OUTPUT_MASK
+  return outputType === bitcoin.Transaction.SIGHASH_SINGLE
+}
+
 interface InputInfo {
   txid: string
   vout: number
@@ -323,6 +329,16 @@ export class PsbtDecoder {
         level: 'danger',
         title: 'sighash_none_risk_title',
         desc: 'sighash_none_risk_description',
+      })
+    }
+
+    const foundSighashSingle = this._psbt.data.inputs.some(v => isSighashSingleType(v.sighashType))
+    if (foundSighashSingle) {
+      this.risks.push({
+        type: RiskType.SIGHASH_SINGLE,
+        level: 'warning',
+        title: 'sighash_single_risk_title',
+        desc: 'sighash_single_risk_description',
       })
     }
   }

--- a/packages/tx-helpers/test/decode-psbt.test.ts
+++ b/packages/tx-helpers/test/decode-psbt.test.ts
@@ -37,15 +37,16 @@ describe('decode psbt sighash risk detection', () => {
     expect(dangerous.risks.some(r => r.type === RiskType.SIGHASH_NONE)).toBe(true)
   })
 
-  it('does not flag SIGHASH_SINGLE | ANYONECANPAY as dangerous', async () => {
-    const safe = await decodeWithSighashType(
+  it('flags SIGHASH_SINGLE | ANYONECANPAY as warning', async () => {
+    const single = await decodeWithSighashType(
       bitcoin.Transaction.SIGHASH_SINGLE | bitcoin.Transaction.SIGHASH_ANYONECANPAY
     )
-    expect(safe.risks.some(r => r.type === RiskType.SIGHASH_NONE)).toBe(false)
+    expect(single.risks.some(r => r.type === RiskType.SIGHASH_SINGLE)).toBe(true)
   })
 
   it('does not flag SIGHASH_ALL as dangerous', async () => {
     const safe = await decodeWithSighashType(bitcoin.Transaction.SIGHASH_ALL)
     expect(safe.risks.some(r => r.type === RiskType.SIGHASH_NONE)).toBe(false)
+    expect(safe.risks.some(r => r.type === RiskType.SIGHASH_SINGLE)).toBe(false)
   })
 })

--- a/packages/wallet-shared/src/types/decode-tx.ts
+++ b/packages/wallet-shared/src/types/decode-tx.ts
@@ -24,6 +24,7 @@ export enum RiskType {
   ALKANES_BURNING,
   ALKANES_MULTIPLE_ASSETS,
   UTXO_INDEXING,
+  SIGHASH_SINGLE,
 }
 
 export interface Risk {


### PR DESCRIPTION
## Summary
- Detect `SIGHASH_SINGLE` in local PSBT decode (`tx-helpers`)
- Add `RiskType.SIGHASH_SINGLE` + EN locale strings
- Surface warning in `SignPsbtWithRisksPopover`

Users get an explicit risk banner for SINGLE sighash (partial-sign footgun), consistent with other decode risks.

Split from #8 for focused review.

## Test plan

- [x] `tx-helpers` unit coverage for `SIGHASH_SINGLE` decode path (Local Tested)
- [ ] SignPsbt UI shows localized `sighash_single_risk_*` warning when present
- [ ] Normal SIGHASH_ALL PSBTs unchanged (no false warning)