### PR TITLE
feat(descriptor-service): BIP-380 singlesig descriptors package

### DIFF
--- a/packages/descriptor-service/README.md
+++ b/packages/descriptor-service/README.md
@@ -1,0 +1,13 @@
+# @unisat/descriptor-service
+
+BIP-380 singlesig output descriptors for UniSat Wallet.
+
+## v1
+
+- BIP-380 checksum (BigInt polymod) + parse / script-type policy label
+- `hdAccountToDescriptor` / `hdAccountToDescriptorPair` for `P2WPKH` / `P2TR` / `P2SH_P2WPKH` / `P2PKH`
+- `deriveAddresses` for ranged singlesig `wpkh` / `tr` / `sh(wpkh)` / `pkh`
+- `normalizeMultipathImport` for Sparrow-style `/<0;1>/*` → receive `/0/*` + change `/1/*`
+- Rejects private `xprv`, SLIP-132, hardened-after-xpub, and non-Sparrow multipath
+
+Multisig / Miniscript script trees are out of scope for v1.

--- a/packages/descriptor-service/package.json
+++ b/packages/descriptor-service/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@unisat/descriptor-service",
+  "version": "0.1.0",
+  "description": "BIP-380 singlesig output descriptors for UniSat Wallet",
+  "private": true,
+  "main": "lib/index.js",
+  "module": "lib/index.mjs",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib/**/*",
+    "src/**/*",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "require": "./lib/index.js",
+      "import": "./lib/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src --ext .ts",
+    "clean": "rm -rf lib",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "bitcoin",
+    "descriptor",
+    "bip380",
+    "unisat"
+  ],
+  "author": "UniSat",
+  "license": "MIT",
+  "dependencies": {
+    "@bitcoinerlab/secp256k1": "^1.0.5",
+    "bip32": "^4.0.0",
+    "bitcoinjs-lib": "^6.1.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20.8.0",
+    "tsup": "^7.2.0",
+    "typescript": "^5.2.0",
+    "vitest": "^0.34.0"
+  }
+}

--- a/packages/descriptor-service/src/account.ts
+++ b/packages/descriptor-service/src/account.ts
@@ -1,0 +1,152 @@
+import { descriptorChecksum } from './checksum'
+import { descriptorBodyWithoutOrigin, extractSinglesigKey } from './derive'
+import { parseDescriptor } from './parse'
+import { normalizeFingerprint, toDescriptorPath } from './path'
+import {
+  DescriptorAddressType,
+  DescriptorError,
+  HdAccountDescriptorInput
+} from './types'
+
+const ORIGIN_DESC_PATH = /^[0-9]+h?(?:\/[0-9]+h?)*$/
+const XPUB_AFTER =
+  '(xpub[1-9A-HJ-NP-Za-km-z]{79,108}|tpub[1-9A-HJ-NP-Za-km-z]{79,108})'
+/** Sparrow / BIP-389 receive+change multipath after the xpub only. */
+const MULTIPATH_01 = new RegExp(`${XPUB_AFTER}/<0;1>/\\*`, 'i')
+
+function wrapperFor(addressType: DescriptorAddressType, keyExpr: string): string {
+  switch (addressType) {
+    case DescriptorAddressType.P2WPKH:
+      return `wpkh(${keyExpr})`
+    case DescriptorAddressType.P2TR:
+      return `tr(${keyExpr})`
+    case DescriptorAddressType.P2SH_P2WPKH:
+      return `sh(wpkh(${keyExpr}))`
+    case DescriptorAddressType.P2PKH:
+      return `pkh(${keyExpr})`
+    default:
+      throw new DescriptorError(
+        `Unsupported address type for descriptor export: ${addressType}`,
+        'UNSUPPORTED'
+      )
+  }
+}
+
+export type XpubLevel = 'account' | 'chain'
+
+/**
+ * Build a checksummed watch-only descriptor for a UniSat HD account xpub.
+ * - account level (default): xpub at m/86'/0'/0' → `…xpub/0/*`
+ * - chain level: xpub at m/86'/0'/0'/0 → `…xpub/*`
+ */
+export function hdAccountToDescriptor(
+  input: HdAccountDescriptorInput & { xpubLevel?: XpubLevel }
+): string {
+  if (!input.xpub?.startsWith('xpub') && !input.xpub?.startsWith('tpub')) {
+    throw new DescriptorError('Account xpub required (xpub/tpub)', 'UNSUPPORTED')
+  }
+  const level = input.xpubLevel ?? 'account'
+  let suffix: string
+  if (level === 'chain') {
+    suffix = '/*'
+  } else {
+    const chain = input.chain ?? 0
+    if (chain !== 0 && chain !== 1) {
+      throw new DescriptorError('chain must be 0 (receive) or 1 (change)', 'UNSUPPORTED')
+    }
+    suffix = `/${chain}/*`
+  }
+
+  // Omit origin when fingerprint is missing/placeholder — never invent 00000000
+  let keyExpr = `${input.xpub}${suffix}`
+  const rawFpr = input.origin?.fingerprint?.trim()
+  const path = input.origin?.path?.trim()
+  if (rawFpr && path && !/^0+$/.test(rawFpr.replace(/^0x/i, ''))) {
+    const fpr = normalizeFingerprint(rawFpr)
+    const descPath = toDescriptorPath(path)
+    if (!ORIGIN_DESC_PATH.test(descPath)) {
+      throw new DescriptorError(`Invalid origin path: ${path}`, 'PARSE')
+    }
+    keyExpr = `[${fpr}/${descPath}]${input.xpub}${suffix}`
+  }
+
+  const body = wrapperFor(input.addressType, keyExpr)
+  return `${body}#${descriptorChecksum(body)}`
+}
+
+/** Convenience: both receive and change descriptors. */
+export function hdAccountToDescriptorPair(input: Omit<HdAccountDescriptorInput, 'chain'>): {
+  receive: string
+  change: string
+} {
+  return {
+    receive: hdAccountToDescriptor({ ...input, chain: 0 }),
+    change: hdAccountToDescriptor({ ...input, chain: 1 })
+  }
+}
+
+/**
+ * Expand Sparrow-style checksummed multipath `…xpub/<0;1>/*` into receive `/0/*` + change `/1/*`.
+ * Returns null when the descriptor is not multipath (caller keeps the original).
+ * Rejects other multipath forms (wrong order, extra branches, nested).
+ */
+export function normalizeMultipathImport(
+  rawDescriptor: string
+): { receive: string; change: string } | null {
+  const parsed = parseDescriptor(rawDescriptor.trim())
+  const keyBody = descriptorBodyWithoutOrigin(parsed.body)
+  if (!keyBody.includes('<') && !keyBody.includes(';')) {
+    return null
+  }
+  MULTIPATH_01.lastIndex = 0
+  if (!MULTIPATH_01.test(parsed.body)) {
+    throw new DescriptorError(
+      'Only Sparrow-style multipath /<0;1>/* is supported; paste receive ending in /0/* or a single /<0;1>/* descriptor',
+      'UNSUPPORTED'
+    )
+  }
+  MULTIPATH_01.lastIndex = 0
+  const receiveBody = parsed.body.replace(MULTIPATH_01, '$1/0/*')
+  MULTIPATH_01.lastIndex = 0
+  const changeBody = parsed.body.replace(MULTIPATH_01, '$1/1/*')
+  if (
+    receiveBody === parsed.body ||
+    changeBody === parsed.body ||
+    receiveBody.includes('<') ||
+    receiveBody.includes(';') ||
+    changeBody.includes('<') ||
+    changeBody.includes(';')
+  ) {
+    throw new DescriptorError(
+      'Only Sparrow-style multipath /<0;1>/* is supported; paste receive ending in /0/* or a single /<0;1>/* descriptor',
+      'UNSUPPORTED'
+    )
+  }
+  return {
+    receive: `${receiveBody}#${descriptorChecksum(receiveBody)}`,
+    change: `${changeBody}#${descriptorChecksum(changeBody)}`,
+  }
+}
+
+/**
+ * From a checksummed receive descriptor ending in `/0/*`, build the sibling `/1/*` change descriptor.
+ * Returns undefined if the input is not a standard receive wildcard shape.
+ * Only rewrites the key-expression `/0/*` after the xpub — never an origin path.
+ */
+export function siblingChangeDescriptor(receiveDescriptor: string): string | undefined {
+  const parsed = parseDescriptor(receiveDescriptor)
+  if (!descriptorBodyWithoutOrigin(parsed.body).includes('/0/*')) return undefined
+  let keyInfo
+  try {
+    keyInfo = extractSinglesigKey(parsed.body)
+  } catch {
+    return undefined
+  }
+  if (keyInfo.chainPath !== '0') return undefined
+  const changeBody = parsed.body.replace(
+    new RegExp(`${XPUB_AFTER}/0/\\*`, 'i'),
+    '$1/1/*'
+  )
+  if (changeBody === parsed.body) return undefined
+  return `${changeBody}#${descriptorChecksum(changeBody)}`
+}

--- a/packages/descriptor-service/src/bitcoin.ts
+++ b/packages/descriptor-service/src/bitcoin.ts
@@ -1,0 +1,16 @@
+import * as ecc from '@bitcoinerlab/secp256k1'
+import { BIP32Factory, BIP32Interface } from 'bip32'
+import * as bitcoin from 'bitcoinjs-lib'
+
+bitcoin.initEccLib(ecc)
+
+export const bip32 = BIP32Factory(ecc)
+export { bitcoin, BIP32Interface }
+
+export function networkFromName(
+  name: 'mainnet' | 'testnet' | 'signet' | 'regtest' = 'mainnet'
+): bitcoin.Network {
+  if (name === 'regtest') return bitcoin.networks.regtest
+  if (name === 'testnet' || name === 'signet') return bitcoin.networks.testnet
+  return bitcoin.networks.bitcoin
+}

--- a/packages/descriptor-service/src/checksum.ts
+++ b/packages/descriptor-service/src/checksum.ts
@@ -1,0 +1,78 @@
+/**
+ * BIP-380 descriptor checksum (reference algorithm from the BIP).
+ * Uses BigInt because JS bitwise operators are 32-bit; polymod needs ~40 bits.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki
+ */
+
+const INPUT_CHARSET =
+  "0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ "
+const CHECKSUM_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
+const GENERATOR = [
+  0xf5dee51989n,
+  0xa9fdca3312n,
+  0x1bab10e32dn,
+  0x3706b1677an,
+  0x644d626ffdn
+]
+const MASK_35 = 0x7ffffffffn
+
+function polyMod(symbols: number[]): bigint {
+  let chk = 1n
+  for (const value of symbols) {
+    const top = chk >> 35n
+    chk = ((chk & MASK_35) << 5n) ^ BigInt(value)
+    for (let i = 0; i < 5; i++) {
+      if ((top >> BigInt(i)) & 1n) chk ^= GENERATOR[i]
+    }
+  }
+  return chk
+}
+
+function expand(s: string): number[] | null {
+  const groups: number[] = []
+  const symbols: number[] = []
+  for (const c of s) {
+    const v = INPUT_CHARSET.indexOf(c)
+    if (v === -1) return null
+    symbols.push(v & 31)
+    groups.push(v >> 5)
+    if (groups.length === 3) {
+      symbols.push(groups[0] * 9 + groups[1] * 3 + groups[2])
+      groups.length = 0
+    }
+  }
+  if (groups.length === 1) {
+    symbols.push(groups[0])
+  } else if (groups.length === 2) {
+    symbols.push(groups[0] * 3 + groups[1])
+  }
+  return symbols
+}
+
+/** Return 8-character checksum for descriptor body (no '#'). */
+export function descriptorChecksum(body: string): string {
+  const expanded = expand(body)
+  if (!expanded) {
+    throw new Error('Invalid descriptor character set')
+  }
+  const symbols = expanded.concat([0, 0, 0, 0, 0, 0, 0, 0])
+  const checksum = polyMod(symbols) ^ 1n
+  let out = ''
+  for (let i = 0; i < 8; i++) {
+    out += CHECKSUM_CHARSET[Number((checksum >> BigInt(5 * (7 - i))) & 31n)]
+  }
+  return out
+}
+
+export function verifyDescriptorChecksum(raw: string): boolean {
+  if (raw.length < 10 || raw[raw.length - 9] !== '#') return false
+  const checksum = raw.slice(-8)
+  if (![...checksum].every((c) => CHECKSUM_CHARSET.includes(c))) return false
+  const body = raw.slice(0, -9)
+  const expanded = expand(body)
+  if (!expanded) return false
+  const symbols = expanded.concat(
+    [...checksum].map((c) => CHECKSUM_CHARSET.indexOf(c))
+  )
+  return polyMod(symbols) === 1n
+}

--- a/packages/descriptor-service/src/derive.ts
+++ b/packages/descriptor-service/src/derive.ts
@@ -1,0 +1,263 @@
+import { bip32, bitcoin, networkFromName } from './bitcoin'
+import { parseDescriptor } from './parse'
+import { toBip32Path } from './path'
+import {
+  DeriveAddressOptions,
+  DescriptorError,
+  DescriptorScriptKind
+} from './types'
+
+interface SinglesigKeyInfo {
+  kind: DescriptorScriptKind
+  xpub: string
+  /** Relative path after xpub before wildcard, e.g. `0` for `/0/*` */
+  chainPath: string
+}
+
+/**
+ * Extract singlesig xpub + chain from a limited set of descriptor shapes:
+ * wpkh(...), tr(...), sh(wpkh(...)), pkh(...)
+ *
+ * Origin path: digits + h/' only — never `*` or hex letters (avoids /* phishing in [fpr/…]).
+ */
+const ORIGIN_PATH = '([0-9]+[hH\']?(?:\\/[0-9]+[hH\']?)*)'
+const XPUB =
+  '(xpub[1-9A-HJ-NP-Za-km-z]{79,108}|tpub[1-9A-HJ-NP-Za-km-z]{79,108})'
+/** Key expression after xpub: must end with `*` for v1 ranged import/derive. */
+const AFTER_XPUB = '([0-9hH/\'*]+)'
+
+/** Non-hardened BIP32 child index must be < 2^31. */
+const MAX_NON_HARDENED_INDEX = 0x80000000
+
+/** Body with `[fpr/path]` stripped — use for /* /0/* /1/* presence checks. */
+export function descriptorBodyWithoutOrigin(body: string): string {
+  return body.replace(/\[[0-9a-fA-F]{8}\/[0-9]+[hH']?(?:\/[0-9]+[hH']?)*\]/g, '')
+}
+
+export function extractSinglesigKey(body: string): SinglesigKeyInfo {
+  // Reject private extended keys at key boundaries (not substring of a valid xpub)
+  if (/(?:^|[[(,/\s])([xtyuz]prv)/i.test(body)) {
+    throw new DescriptorError(
+      'Private descriptors (xprv) are not supported; use a watch-only xpub descriptor',
+      'UNSUPPORTED'
+    )
+  }
+  // Raw multipath is not a single chainPath — expand /<0;1>/* via normalizeMultipathImport first
+  if (body.includes('<') || body.includes(';')) {
+    throw new DescriptorError(
+      'Multipath descriptors must be normalized first (use normalizeMultipathImport for /<0;1>/*, else paste /0/*)',
+      'UNSUPPORTED'
+    )
+  }
+  // SLIP-132 versions — common from Electrum/Ledger; fail with a targeted hint
+  if (/(?:^|[[(,/\s])([yzuv]pub)/i.test(body)) {
+    throw new DescriptorError(
+      'SLIP-132 keys (ypub/zpub/upub/vpub) are not supported; convert to BIP-32 xpub/tpub',
+      'UNSUPPORTED'
+    )
+  }
+  // v1: key-path Taproot only (no script tree)
+  if (body.startsWith('tr(') && body.includes(',{')) {
+    throw new DescriptorError(
+      'Taproot script-path descriptors are not supported in v1',
+      'UNSUPPORTED'
+    )
+  }
+
+  const patterns: { kind: DescriptorScriptKind; re: RegExp }[] = [
+    {
+      kind: 'sh-wpkh',
+      re: new RegExp(
+        `^sh\\(wpkh\\((?:\\[([0-9a-fA-F]{8})\\/${ORIGIN_PATH}\\])?${XPUB}(?:\\/${AFTER_XPUB})?\\)\\)$`
+      )
+    },
+    {
+      kind: 'wpkh',
+      re: new RegExp(
+        `^wpkh\\((?:\\[([0-9a-fA-F]{8})\\/${ORIGIN_PATH}\\])?${XPUB}(?:\\/${AFTER_XPUB})?\\)$`
+      )
+    },
+    {
+      kind: 'tr',
+      re: new RegExp(
+        `^tr\\((?:\\[([0-9a-fA-F]{8})\\/${ORIGIN_PATH}\\])?${XPUB}(?:\\/${AFTER_XPUB})?(?:,\\{[^)]+\\})?\\)$`
+      )
+    },
+    {
+      kind: 'pkh',
+      re: new RegExp(
+        `^pkh\\((?:\\[([0-9a-fA-F]{8})\\/${ORIGIN_PATH}\\])?${XPUB}(?:\\/${AFTER_XPUB})?\\)$`
+      )
+    }
+  ]
+
+  for (const { kind, re } of patterns) {
+    const m = body.match(re)
+    if (!m) continue
+    const xpub = m[3]
+    const rawAfter = m[4] || ''
+    if (!xpub) {
+      throw new DescriptorError('Could not parse xpub from descriptor', 'PARSE')
+    }
+    // Fail closed: fixed paths (…/0/0) must not be treated as a gap
+    if (!rawAfter.endsWith('*')) {
+      throw new DescriptorError(
+        'Ranged descriptor required (must end with /*), e.g. wpkh(xpub…/0/*)#checksum',
+        'UNSUPPORTED'
+      )
+    }
+    const after = rawAfter.replace(/\/?\*$/, '').replace(/^\//, '')
+    // Public nodes cannot harden; fail closed before bip32 throws
+    if (/[hH']/.test(after)) {
+      throw new DescriptorError('Hardened derivation after xpub is not supported', 'UNSUPPORTED')
+    }
+    // v1: only /* (chain-level), /0/* (receive), /1/* (change)
+    if (after !== '' && after !== '0' && after !== '1') {
+      throw new DescriptorError(
+        'Only /*, /0/*, or /1/* wildcards are supported in v1',
+        'UNSUPPORTED'
+      )
+    }
+    return { kind, xpub, chainPath: after }
+  }
+
+  throw new DescriptorError(
+    'Only singlesig wpkh/tr/sh(wpkh)/pkh descriptors are supported in v1',
+    'UNSUPPORTED'
+  )
+}
+
+function pubkeyToAddress(
+  kind: DescriptorScriptKind,
+  pubkey: Buffer,
+  network: bitcoin.Network
+): string {
+  if (kind === 'wpkh') {
+    const { address } = bitcoin.payments.p2wpkh({ pubkey, network })
+    if (!address) throw new DescriptorError('Failed to derive wpkh address', 'DERIVE')
+    return address
+  }
+  if (kind === 'sh-wpkh') {
+    const redeem = bitcoin.payments.p2wpkh({ pubkey, network })
+    const { address } = bitcoin.payments.p2sh({ redeem, network })
+    if (!address) throw new DescriptorError('Failed to derive sh-wpkh address', 'DERIVE')
+    return address
+  }
+  if (kind === 'pkh') {
+    const { address } = bitcoin.payments.p2pkh({ pubkey, network })
+    if (!address) throw new DescriptorError('Failed to derive pkh address', 'DERIVE')
+    return address
+  }
+  if (kind === 'tr') {
+    const { address } = bitcoin.payments.p2tr({
+      internalPubkey: pubkey.subarray(1, 33),
+      network
+    })
+    if (!address) throw new DescriptorError('Failed to derive tr address', 'DERIVE')
+    return address
+  }
+  throw new DescriptorError(`Cannot derive addresses for kind ${kind}`, 'UNSUPPORTED')
+}
+
+function deriveChildPubkey(
+  xpub: string,
+  chainPath: string,
+  index: number,
+  network: bitcoin.Network
+): Buffer {
+  if (!Number.isInteger(index) || index < 0 || index >= MAX_NON_HARDENED_INDEX) {
+    throw new DescriptorError(
+      `Derivation index out of range (0..${MAX_NON_HARDENED_INDEX - 1})`,
+      'DERIVE'
+    )
+  }
+  let node
+  try {
+    node = bip32.fromBase58(xpub, network)
+  } catch {
+    throw new DescriptorError(
+      'Invalid xpub for the selected network (mainnet xpub vs testnet tpub mismatch?)',
+      'DERIVE'
+    )
+  }
+  if (chainPath) {
+    // chainPath may be `0` or `0/1` style without wildcard
+    const rel = chainPath
+      .split('/')
+      .filter(Boolean)
+      .map((p) => p.replace(/h$/i, "'"))
+      .join('/')
+    if (rel.includes('*')) {
+      throw new DescriptorError('Unexpected wildcard in chain path', 'PARSE')
+    }
+    if (rel) {
+      try {
+        node = node.derivePath(rel) as typeof node
+      } catch {
+        throw new DescriptorError('Failed to derive chain path from xpub', 'DERIVE')
+      }
+    }
+  }
+  const child = node.derive(index)
+  return Buffer.from(child.publicKey)
+}
+
+/**
+ * Derive receive/change addresses from a checksummed singlesig descriptor.
+ */
+export function deriveAddresses(
+  rawDescriptor: string,
+  options: DeriveAddressOptions = {}
+): string[] {
+  const parsed = parseDescriptor(rawDescriptor)
+  // Ignore /* inside origin [fpr/…] — only the key expression after xpub counts
+  if (!descriptorBodyWithoutOrigin(parsed.body).includes('/*')) {
+    throw new DescriptorError(
+      'Ranged descriptor required (must include /*), e.g. wpkh(xpub…/0/*)#checksum',
+      'UNSUPPORTED'
+    )
+  }
+  const { kind, xpub, chainPath } = extractSinglesigKey(parsed.body)
+  const network = networkFromName(options.network ?? 'mainnet')
+  const start = options.start ?? 0
+  const count = options.count ?? 1
+  if (!Number.isInteger(start) || start < 0) {
+    throw new DescriptorError('start must be a non-negative integer', 'DERIVE')
+  }
+  if (!Number.isInteger(count) || count < 1 || count > 1000) {
+    throw new DescriptorError('count must be between 1 and 1000', 'DERIVE')
+  }
+  if (start + count > MAX_NON_HARDENED_INDEX) {
+    throw new DescriptorError(
+      `start+count exceeds max non-hardened index (${MAX_NON_HARDENED_INDEX - 1})`,
+      'DERIVE'
+    )
+  }
+
+  const out: string[] = []
+  for (let i = 0; i < count; i++) {
+    const pubkey = deriveChildPubkey(xpub, chainPath, start + i, network)
+    out.push(pubkeyToAddress(kind, pubkey, network))
+  }
+  return out
+}
+
+export function addressTypeHintFromKind(
+  kind: DescriptorScriptKind
+): 'P2WPKH' | 'P2TR' | 'P2SH_P2WPKH' | 'P2PKH' | 'UNKNOWN' {
+  switch (kind) {
+    case 'wpkh':
+      return 'P2WPKH'
+    case 'tr':
+      return 'P2TR'
+    case 'sh-wpkh':
+      return 'P2SH_P2WPKH'
+    case 'pkh':
+      return 'P2PKH'
+    default:
+      return 'UNKNOWN'
+  }
+}
+
+/** Re-export for callers that need path conversion when building from HD. */
+export { toBip32Path }

--- a/packages/descriptor-service/src/index.ts
+++ b/packages/descriptor-service/src/index.ts
@@ -1,0 +1,26 @@
+export { descriptorChecksum, verifyDescriptorChecksum } from './checksum'
+export { parseDescriptor } from './parse'
+export {
+  hdAccountToDescriptor,
+  hdAccountToDescriptorPair,
+  normalizeMultipathImport,
+  siblingChangeDescriptor
+} from './account'
+export type { XpubLevel } from './account'
+export {
+  deriveAddresses,
+  extractSinglesigKey,
+  addressTypeHintFromKind,
+  descriptorBodyWithoutOrigin
+} from './derive'
+export { toDescriptorPath, toBip32Path, normalizeFingerprint } from './path'
+export type {
+  DescriptorNetwork,
+  DescriptorScriptKind,
+  ParsedDescriptor,
+  PolicySummary,
+  KeyOrigin,
+  HdAccountDescriptorInput,
+  DeriveAddressOptions
+} from './types'
+export { DescriptorError, DescriptorAddressType } from './types'

--- a/packages/descriptor-service/src/parse.ts
+++ b/packages/descriptor-service/src/parse.ts
@@ -1,0 +1,75 @@
+import { verifyDescriptorChecksum } from './checksum'
+import {
+  DescriptorError,
+  DescriptorScriptKind,
+  ParsedDescriptor,
+  PolicySummary
+} from './types'
+
+function detectKind(body: string): DescriptorScriptKind {
+  const b = body.trim()
+  if (b.startsWith('tr(')) return 'tr'
+  if (b.startsWith('wpkh(')) return 'wpkh'
+  if (b.startsWith('wsh(')) return 'wsh'
+  if (b.startsWith('sh(wpkh(')) return 'sh-wpkh'
+  if (b.startsWith('sh(')) return 'sh'
+  if (b.startsWith('pkh(')) return 'pkh'
+  return 'unknown'
+}
+
+function policyFor(kind: DescriptorScriptKind, body: string): PolicySummary {
+  const complex =
+    kind === 'wsh' ||
+    body.includes('multi(') ||
+    body.includes('multi_a(') ||
+    body.includes('sortedmulti') ||
+    body.includes('thresh(') ||
+    body.includes('older(') ||
+    body.includes('after(')
+
+  // Plain-language script type (avoid Miniscript “policy” jargon for singlesig)
+  const labels: Record<DescriptorScriptKind, string> = {
+    tr: complex ? 'Script: Taproot (script paths)' : 'Script: Taproot (single key)',
+    wpkh: 'Script: Native SegWit (single key)',
+    'sh-wpkh': 'Script: Nested SegWit (single key)',
+    wsh: 'Script: SegWit (multisig / miniscript)',
+    sh: 'Script: Legacy P2SH',
+    pkh: 'Script: Legacy P2PKH',
+    unknown: 'Script: Unknown'
+  }
+
+  return {
+    label: labels[kind],
+    kind,
+    isComplex: complex
+  }
+}
+
+/**
+ * Validate BIP-380 checksum and return a lightweight parse (kind + policy label).
+ * Address derivation is `deriveAddresses` / `extractSinglesigKey`.
+ */
+export function parseDescriptor(raw: string): ParsedDescriptor {
+  const trimmed = raw.trim()
+  if (!trimmed) {
+    throw new DescriptorError('Descriptor is empty', 'EMPTY')
+  }
+  // Checksum is exactly 8 chars after a final '#'; reject other '#' placements.
+  if (trimmed.length < 10 || trimmed[trimmed.length - 9] !== '#') {
+    throw new DescriptorError('Descriptor missing #checksum', 'MISSING_CHECKSUM')
+  }
+  if (!verifyDescriptorChecksum(trimmed)) {
+    throw new DescriptorError('Descriptor checksum invalid', 'INVALID_CHECKSUM')
+  }
+  const hash = trimmed.length - 9
+  const body = trimmed.slice(0, hash)
+  const checksum = trimmed.slice(hash + 1)
+  const kind = detectKind(body)
+  return {
+    raw: trimmed,
+    body,
+    checksum,
+    kind,
+    policy: policyFor(kind, body)
+  }
+}

--- a/packages/descriptor-service/src/path.ts
+++ b/packages/descriptor-service/src/path.ts
@@ -1,0 +1,21 @@
+/** Normalize BIP-32 path to descriptor form: `86h/0h/0h` (no leading m/). */
+export function toDescriptorPath(path: string): string {
+  let p = path.trim()
+  if (p.startsWith('m/')) p = p.slice(2)
+  else if (p.startsWith('m')) p = p.slice(1).replace(/^\//, '')
+  return p.replace(/'/g, 'h')
+}
+
+/** Convert descriptor path `86h/0h/0h` to bip32 `m/86'/0'/0'`. */
+export function toBip32Path(path: string): string {
+  const body = toDescriptorPath(path).replace(/h/g, "'")
+  return body.startsWith('m/') ? body : `m/${body}`
+}
+
+export function normalizeFingerprint(fingerprint: string): string {
+  const hex = fingerprint.trim().toLowerCase().replace(/^0x/, '')
+  if (!/^[0-9a-f]{8}$/.test(hex)) {
+    throw new Error(`Invalid master fingerprint: ${fingerprint}`)
+  }
+  return hex
+}

--- a/packages/descriptor-service/src/types.ts
+++ b/packages/descriptor-service/src/types.ts
@@ -1,0 +1,85 @@
+export type DescriptorNetwork = 'mainnet' | 'testnet' | 'signet' | 'regtest'
+
+/** High-level script family for UI policy chips */
+export type DescriptorScriptKind =
+  | 'wpkh'
+  | 'sh-wpkh'
+  | 'tr'
+  | 'wsh'
+  | 'sh'
+  | 'pkh'
+  | 'unknown'
+
+/**
+ * UniSat AddressType subset supported for descriptor export/derive (v1).
+ * Numeric values match `@unisat/wallet-types` AddressType.
+ */
+export enum DescriptorAddressType {
+  P2PKH = 0,
+  P2WPKH = 1,
+  P2TR = 2,
+  P2SH_P2WPKH = 3
+}
+
+export interface PolicySummary {
+  /** Short label for UI, e.g. "Taproot single key" */
+  label: string
+  kind: DescriptorScriptKind
+  /** True if more than one key or a miniscript threshold/timelock is present */
+  isComplex: boolean
+}
+
+export interface ParsedDescriptor {
+  /** Full input including checksum */
+  raw: string
+  /** Descriptor without #checksum */
+  body: string
+  checksum: string
+  kind: DescriptorScriptKind
+  policy: PolicySummary
+}
+
+export interface KeyOrigin {
+  /** 8 hex chars (4-byte master fingerprint), no 0x */
+  fingerprint: string
+  /**
+   * Hardened account path using `h` or `'`, with or without leading `m/`.
+   * Example: `86h/0h/0h` or `m/86'/0'/0'`
+   */
+  path: string
+}
+
+export interface HdAccountDescriptorInput {
+  addressType: DescriptorAddressType
+  /**
+   * Key origin. Omit or leave fingerprint empty/zero to export without `[fpr/path]`
+   * (preferred over inventing `00000000`).
+   */
+  origin?: KeyOrigin
+  /** Account-level xpub (e.g. at m/86'/0'/0') */
+  xpub: string
+  /** Receive (0) or change (1). Default receive. */
+  chain?: 0 | 1
+}
+
+export interface DeriveAddressOptions {
+  network?: DescriptorNetwork
+  start?: number
+  count?: number
+}
+
+export class DescriptorError extends Error {
+  constructor(
+    message: string,
+    readonly code:
+      | 'EMPTY'
+      | 'MISSING_CHECKSUM'
+      | 'INVALID_CHECKSUM'
+      | 'UNSUPPORTED'
+      | 'PARSE'
+      | 'DERIVE'
+  ) {
+    super(message)
+    this.name = 'DescriptorError'
+  }
+}

--- a/packages/descriptor-service/test/account-origin.test.ts
+++ b/packages/descriptor-service/test/account-origin.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { hdAccountToDescriptor, parseDescriptor, verifyDescriptorChecksum } from '../src'
+import { DescriptorAddressType } from '../src/types'
+
+const WPKH_XPUB =
+  'xpub6CatWdiZiodmUeTDp8LT5or8nmbKNcuyvz7WyksVFkKB4RHwCD3XyuvPEbvqAQY3rAPshWcMLoP2fMFMKHPJ4ZeZXYVUhLv1VMrjPC7PW6V'
+
+describe('hdAccountToDescriptor origin handling', () => {
+  it('includes origin when fingerprint is real', () => {
+    const d = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: '73c5da0a', path: "m/84'/0'/0'" },
+      xpub: WPKH_XPUB,
+      chain: 0
+    })
+    expect(d.startsWith('wpkh([73c5da0a/84h/0h/0h]')).toBe(true)
+    expect(verifyDescriptorChecksum(d)).toBe(true)
+  })
+
+  it('omits origin when fingerprint is missing (never invents 00000000)', () => {
+    const d = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      xpub: WPKH_XPUB,
+      xpubLevel: 'chain'
+    })
+    expect(d.includes('[')).toBe(false)
+    expect(d.includes('00000000')).toBe(false)
+    expect(d.startsWith('wpkh(')).toBe(true)
+    expect(verifyDescriptorChecksum(d)).toBe(true)
+    expect(parseDescriptor(d).policy.kind).toBe('wpkh')
+  })
+
+  it('omits origin when fingerprint is all zeros', () => {
+    const d = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: '00000000', path: "m/84'/0'/0'/0" },
+      xpub: WPKH_XPUB,
+      xpubLevel: 'chain'
+    })
+    expect(d.includes('00000000')).toBe(false)
+    expect(d.includes('[')).toBe(false)
+  })
+})

--- a/packages/descriptor-service/test/bip-vectors.test.ts
+++ b/packages/descriptor-service/test/bip-vectors.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DescriptorAddressType,
+  deriveAddresses,
+  descriptorChecksum,
+  hdAccountToDescriptor,
+  hdAccountToDescriptorPair,
+  normalizeMultipathImport,
+  parseDescriptor,
+  siblingChangeDescriptor,
+  verifyDescriptorChecksum
+} from '../src'
+
+/**
+ * Official BIP test vectors — abandon…about (master fpr 73c5da0a).
+ * These are the Sparrow / Bitcoin Core interop anchors for PR1–PR5.
+ */
+const FPR = '73c5da0a'
+const MNEMONIC_NOTE = 'abandon…about'
+
+// Account-level xpubs from UniSat/hdkey (BIP-32 xpub, not SLIP-132 zpub)
+const WPKH_XPUB =
+  'xpub6CatWdiZiodmUeTDp8LT5or8nmbKNcuyvz7WyksVFkKB4RHwCD3XyuvPEbvqAQY3rAPshWcMLoP2fMFMKHPJ4ZeZXYVUhLv1VMrjPC7PW6V'
+const TR_XPUB =
+  'xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ'
+
+describe(`BIP vectors (${MNEMONIC_NOTE})`, () => {
+  it('BIP-84 receive 0/1 and change 0', () => {
+    const pair = hdAccountToDescriptorPair({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: "m/84'/0'/0'" },
+      xpub: WPKH_XPUB
+    })
+    expect(pair.receive.startsWith(`wpkh([${FPR}/84h/0h/0h]${WPKH_XPUB}/0/*)#`)).toBe(true)
+    expect(verifyDescriptorChecksum(pair.receive)).toBe(true)
+    expect(verifyDescriptorChecksum(pair.change)).toBe(true)
+
+    const recv = deriveAddresses(pair.receive, { count: 2 })
+    expect(recv[0]).toBe('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu')
+    expect(recv[1]).toBe('bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g')
+    expect(deriveAddresses(pair.change, { count: 1 })[0]).toBe(
+      'bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el'
+    )
+    expect(siblingChangeDescriptor(pair.receive)).toBe(pair.change)
+  })
+
+  it('BIP-86 taproot receive 0', () => {
+    const receive = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2TR,
+      origin: { fingerprint: FPR, path: "m/86'/0'/0'" },
+      xpub: TR_XPUB,
+      chain: 0
+    })
+    expect(parseDescriptor(receive).kind).toBe('tr')
+    expect(deriveAddresses(receive, { count: 1 })[0]).toBe(
+      'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr'
+    )
+    const change = siblingChangeDescriptor(receive)
+    expect(change).toBeTruthy()
+    expect(change!.includes('/1/*')).toBe(true)
+  })
+
+  it('Sparrow multipath /<0;1>/* expands to BIP-84 receive+change', () => {
+    const multiBody = `wpkh([${FPR}/84h/0h/0h]${WPKH_XPUB}/<0;1>/*)`
+    const multi = `${multiBody}#${descriptorChecksum(multiBody)}`
+    const expanded = normalizeMultipathImport(multi)
+    expect(expanded).toBeTruthy()
+    const pair = hdAccountToDescriptorPair({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: "m/84'/0'/0'" },
+      xpub: WPKH_XPUB
+    })
+    expect(expanded!.receive).toBe(pair.receive)
+    expect(expanded!.change).toBe(pair.change)
+    expect(deriveAddresses(expanded!.receive, { count: 1 })[0]).toBe(
+      'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'
+    )
+  })
+
+  it('checksum flip fails (polymod)', () => {
+    const d = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: '84h/0h/0h' },
+      xpub: WPKH_XPUB
+    })
+    const flipped = d.slice(0, -1) + (d.endsWith('a') ? 'b' : 'a')
+    expect(verifyDescriptorChecksum(flipped)).toBe(false)
+    expect(() => parseDescriptor(flipped)).toThrow(/checksum|invalid/i)
+  })
+
+  it('policy labels are script-type wording', () => {
+    const d = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: '84h/0h/0h' },
+      xpub: WPKH_XPUB
+    })
+    const { policy } = parseDescriptor(d)
+    expect(policy.label.toLowerCase()).toContain('native segwit')
+    expect(policy.label.toLowerCase()).toContain('script')
+    expect(policy.isComplex).toBe(false)
+  })
+})

--- a/packages/descriptor-service/test/checksum.test.ts
+++ b/packages/descriptor-service/test/checksum.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  descriptorChecksum,
+  parseDescriptor,
+  verifyDescriptorChecksum
+} from '../src'
+
+describe('BIP-380 checksum', () => {
+  it('matches BIP vector raw(deadbeef)#89f8spxm', () => {
+    expect(descriptorChecksum('raw(deadbeef)')).toBe('89f8spxm')
+    expect(verifyDescriptorChecksum('raw(deadbeef)#89f8spxm')).toBe(true)
+  })
+
+  it('accepts checksummed wpkh with origin + wildcard', () => {
+    const body =
+      "wpkh([d34db33f/84h/0h/0h]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/0/*)"
+    const raw = `${body}#${descriptorChecksum(body)}`
+    expect(raw.endsWith('#h36s06su')).toBe(true)
+    const parsed = parseDescriptor(raw)
+    expect(parsed.kind).toBe('wpkh')
+    expect(parsed.policy.isComplex).toBe(false)
+  })
+
+  it('rejects missing checksum', () => {
+    expect(() => parseDescriptor('wpkh(xpub...)')).toThrow(/checksum/i)
+  })
+
+  it('rejects bad checksum', () => {
+    expect(() => parseDescriptor('raw(deadbeef)#qqqqqqqq')).toThrow(/invalid/i)
+  })
+
+  it('labels tr() singlesig', () => {
+    const body =
+      'tr([00000000/86h/0h/0h]xpub6BgBgsespWvERF3LHSw6pxgKvJT7WatA4owFbrMx5XfYTSUqvCFK8YrSTHhsrrNyrpCbwrcxdMzvQ5zZHnf8SHPX8KxdQdQdXXjtSGjzzX/0/*)'
+    const raw = `${body}#${descriptorChecksum(body)}`
+    const parsed = parseDescriptor(raw)
+    expect(parsed.kind).toBe('tr')
+    expect(parsed.policy.isComplex).toBe(false)
+  })
+})

--- a/packages/descriptor-service/test/derive.test.ts
+++ b/packages/descriptor-service/test/derive.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DescriptorAddressType,
+  deriveAddresses,
+  hdAccountToDescriptor,
+  hdAccountToDescriptorPair,
+  parseDescriptor
+} from '../src'
+
+// BIP-39 abandon…about — BIP84/86 account-level vectors
+const FPR = '73c5da0a'
+const WPKH_XPUB =
+  'xpub6CatWdiZiodmUeTDp8LT5or8nmbKNcuyvz7WyksVFkKB4RHwCD3XyuvPEbvqAQY3rAPshWcMLoP2fMFMKHPJ4ZeZXYVUhLv1VMrjPC7PW6V'
+const TR_XPUB =
+  'xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ'
+const WPKH_ADDR0 = 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'
+const TR_ADDR0 = 'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr'
+
+describe('hdAccountToDescriptor + deriveAddresses', () => {
+  it('round-trips UniSat Native SegWit (BIP84)', () => {
+    const desc = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: "m/84'/0'/0'" },
+      xpub: WPKH_XPUB,
+      chain: 0
+    })
+    expect(desc.startsWith(`wpkh([${FPR}/84h/0h/0h]${WPKH_XPUB}/0/*)#`)).toBe(true)
+    const parsed = parseDescriptor(desc)
+    expect(parsed.kind).toBe('wpkh')
+    expect(deriveAddresses(desc, { count: 1 })[0]).toBe(WPKH_ADDR0)
+  })
+
+  it('round-trips UniSat Taproot (BIP86)', () => {
+    const desc = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2TR,
+      origin: { fingerprint: FPR, path: '86h/0h/0h' },
+      xpub: TR_XPUB
+    })
+    expect(parseDescriptor(desc).kind).toBe('tr')
+    expect(deriveAddresses(desc, { count: 1 })[0]).toBe(TR_ADDR0)
+  })
+
+  it('builds receive/change pair', () => {
+    const pair = hdAccountToDescriptorPair({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: '84h/0h/0h' },
+      xpub: WPKH_XPUB
+    })
+    expect(pair.receive.includes('/0/*')).toBe(true)
+    expect(pair.change.includes('/1/*')).toBe(true)
+    expect(deriveAddresses(pair.receive)[0]).toBe(WPKH_ADDR0)
+  })
+
+  it('derives a range of addresses', () => {
+    const desc = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: '84h/0h/0h' },
+      xpub: WPKH_XPUB
+    })
+    const addrs = deriveAddresses(desc, { start: 0, count: 3 })
+    expect(addrs).toHaveLength(3)
+    expect(addrs[0]).toBe(WPKH_ADDR0)
+    expect(new Set(addrs).size).toBe(3)
+  })
+
+  it('rejects private xprv material', async () => {
+    const { extractSinglesigKey } = await import('../src')
+    expect(() =>
+      extractSinglesigKey(
+        'wpkh(xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi/0/*)'
+      )
+    ).toThrow(/Private|xprv/i)
+  })
+
+  it('rejects raw multipath in extract; normalize expands Sparrow /<0;1>/*', async () => {
+    const { descriptorChecksum, extractSinglesigKey, normalizeMultipathImport } = await import(
+      '../src'
+    )
+    expect(() => extractSinglesigKey(`wpkh(${WPKH_XPUB}/<0;1>/*)`)).toThrow(/Multipath|normalize/i)
+    expect(() => extractSinglesigKey(`wpkh(${WPKH_XPUB}/0h/*)`)).toThrow(/Hardened/i)
+
+    const multiBody = `wpkh([${FPR}/84h/0h/0h]${WPKH_XPUB}/<0;1>/*)`
+    const multi = `${multiBody}#${descriptorChecksum(multiBody)}`
+    const expanded = normalizeMultipathImport(multi)
+    expect(expanded).toBeTruthy()
+    expect(expanded!.receive.includes('/0/*')).toBe(true)
+    expect(expanded!.change.includes('/1/*')).toBe(true)
+    expect(deriveAddresses(expanded!.receive, { count: 1 })[0]).toBe(WPKH_ADDR0)
+    expect(normalizeMultipathImport(expanded!.receive)).toBeNull()
+  })
+
+  it('rejects exotic multipath and out-of-range derive indices', async () => {
+    const { descriptorChecksum, normalizeMultipathImport } = await import('../src')
+    const badBody = `wpkh([${FPR}/84h/0h/0h]${WPKH_XPUB}/<1;0>/*)`
+    const bad = `${badBody}#${descriptorChecksum(badBody)}`
+    expect(() => normalizeMultipathImport(bad)).toThrow(/multipath|Sparrow/i)
+
+    const desc = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: '84h/0h/0h' },
+      xpub: WPKH_XPUB
+    })
+    expect(() => deriveAddresses(desc, { start: -1, count: 1 })).toThrow(/start/i)
+    expect(() => deriveAddresses(desc, { start: 0x7fffffff, count: 2 })).toThrow(/index|start\+count/i)
+    expect(() => deriveAddresses(desc, { network: 'testnet', count: 1 })).toThrow(/network|xpub|tpub/i)
+  })
+
+  it('rejects fixed-path descriptors without /* (no silent wrong gap)', async () => {
+    const { descriptorChecksum } = await import('../src')
+    const body = `wpkh(${WPKH_XPUB}/0/0)`
+    const fixed = `${body}#${descriptorChecksum(body)}`
+    expect(() => deriveAddresses(fixed, { count: 2 })).toThrow(/Ranged|\/\*/i)
+  })
+
+  it('rejects origin-path /* phishing (wildcard only after xpub)', async () => {
+    const { descriptorChecksum, extractSinglesigKey } = await import('../src')
+    // Crafted: /* sits inside origin; key expr is fixed /0/0 — must not derive a fake gap
+    const body = `wpkh([${FPR}/84h/*/0h]${WPKH_XPUB}/0/0)`
+    const crafted = `${body}#${descriptorChecksum(body)}`
+    expect(() => deriveAddresses(crafted, { count: 2 })).toThrow()
+    expect(() => extractSinglesigKey(body)).toThrow()
+  })
+
+  it('rejects non-standard chain wildcards like /2/*', async () => {
+    const { extractSinglesigKey } = await import('../src')
+    expect(() => extractSinglesigKey(`wpkh(${WPKH_XPUB}/2/*)`)).toThrow(/\/\*|0\/\*|1\/\*/i)
+  })
+
+  it('rejects SLIP-132 with a clear error', async () => {
+    const { extractSinglesigKey } = await import('../src')
+    expect(() =>
+      extractSinglesigKey(
+        'wpkh(zpub6rFR7y4Q2PFmgxNfZRFeATDvyUyQpcnEd3fxeiwq884RgE8zxX5NwGLhD8y4K6zqH4xK5vQxJzqH4xK5vQxJzqH4xK5vQxJzqH4xK5vQxJ/0/*)'
+      )
+    ).toThrow(/SLIP-132|zpub/i)
+  })
+
+  it('builds chain-level descriptor (OW short path)', () => {
+    const desc = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2TR,
+      origin: { fingerprint: FPR, path: "m/86'/0'/0'" },
+      xpub: TR_XPUB,
+      xpubLevel: 'chain'
+    })
+    expect(desc.includes(`${TR_XPUB}/*)#`)).toBe(true)
+    expect(desc.includes('/0/*')).toBe(false)
+  })
+
+  it('builds sibling change descriptor from receive', async () => {
+    const { siblingChangeDescriptor } = await import('../src')
+    const receive = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: '84h/0h/0h' },
+      xpub: WPKH_XPUB,
+      chain: 0
+    })
+    const change = siblingChangeDescriptor(receive)
+    expect(change).toBeTruthy()
+    expect(change!.includes('/1/*')).toBe(true)
+    expect(parseDescriptor(change!).kind).toBe('wpkh')
+  })
+})

--- a/packages/descriptor-service/tsconfig.json
+++ b/packages/descriptor-service/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/descriptor-service/tsup.config.ts
+++ b/packages/descriptor-service/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  outDir: 'lib',
+  target: 'es2020'
+})

--- a/packages/descriptor-service/vitest.config.ts
+++ b/packages/descriptor-service/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.{test,spec}.ts']
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -809,6 +809,31 @@ importers:
         specifier: ^0.34.0
         version: 0.34.0(jsdom@27.4.0)
 
+  packages/descriptor-service:
+    dependencies:
+      '@bitcoinerlab/secp256k1':
+        specifier: ^1.0.5
+        version: 1.0.5
+      bip32:
+        specifier: ^4.0.0
+        version: 4.0.0
+      bitcoinjs-lib:
+        specifier: ^6.1.6
+        version: 6.1.6(patch_hash=endiwip2ry2tlbgod6aak5qlwa)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.8.0
+        version: 20.8.0
+      tsup:
+        specifier: ^7.2.0
+        version: 7.2.0(typescript@5.2.2)
+      typescript:
+        specifier: ^5.2.0
+        version: 5.2.2
+      vitest:
+        specifier: ^0.34.0
+        version: 0.34.0(jsdom@27.4.0)
+
   packages/keyring-service:
     dependencies:
       '@keystonehq/keystone-sdk':
@@ -1612,7 +1637,7 @@ packages:
       '@babel/traverse': 7.28.4
       '@babel/types': 7.28.4
       convert-source-map: 1.9.0
-      debug: 4.4.1
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4338,7 +4363,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
-      debug: 4.4.1
+      debug: 4.4.3
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -5058,7 +5083,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -5145,7 +5170,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.1
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7896,7 +7921,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.59.0(typescript@4.7.2)
       '@typescript-eslint/utils': 5.59.0(eslint@8.50.0)(typescript@4.7.2)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.50.0
       tsutils: 3.21.0(typescript@4.7.2)
       typescript: 4.7.2
@@ -7965,7 +7990,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.0
       '@typescript-eslint/visitor-keys': 5.59.0
-      debug: 4.4.1
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.2
@@ -9541,6 +9566,7 @@ packages:
 
   /bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    requiresBuild: true
     dependencies:
       file-uri-to-path: 1.0.0
     dev: true
@@ -9560,6 +9586,16 @@ packages:
   /bip174@2.1.1:
     resolution: {integrity: sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==}
     engines: {node: '>=8.0.0'}
+
+  /bip32@4.0.0:
+    resolution: {integrity: sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.1
+      typeforce: 1.18.0
+      wif: 2.0.6
+    dev: false
 
   /bip39@3.1.0:
     resolution: {integrity: sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==}
@@ -12833,6 +12869,7 @@ packages:
 
   /file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -13431,10 +13468,10 @@ packages:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
-      minimatch: 10.0.3
-      minipass: 7.1.2
+      minimatch: 10.2.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
-      path-scurry: 2.0.0
+      path-scurry: 2.0.2
     dev: true
 
   /glob@13.0.6:
@@ -13448,7 +13485,7 @@ packages:
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -16504,13 +16541,6 @@ packages:
   /minimalistic-crypto-utils@1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
-  /minimatch@10.0.3:
-    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
-    engines: {node: 20 || >=22}
-    dependencies:
-      '@isaacs/brace-expansion': 5.0.0
-    dev: true
-
   /minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
@@ -16627,11 +16657,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       yallist: 4.0.0
-    dev: true
-
-  /minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
     dev: true
 
   /minipass@7.1.3:
@@ -16773,6 +16798,7 @@ packages:
 
   /nan@2.23.0:
     resolution: {integrity: sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -17795,14 +17821,6 @@ packages:
     engines: {node: '>=16 || 14 >=14.18'}
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.3
-    dev: true
-
-  /path-scurry@2.0.0:
-    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
-    engines: {node: 20 || >=22}
-    dependencies:
-      lru-cache: 11.2.6
       minipass: 7.1.3
     dev: true
 


### PR DESCRIPTION
Add @unisat/descriptor-service with BIP-380 checksum/parse, singlesig derive, hdAccountToDescriptor, sibling change, and Sparrow /<0;1>/* normalize. Library-only; not wired into wallet UI yet.