### PR TITLE
Feat/desc pr6 ux

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -62,6 +62,7 @@
     "@unisat/babylon-service": "workspace:*",
     "@unisat/base-utils": "workspace:*",
     "@unisat/contact-book": "workspace:*",
+    "@unisat/descriptor-service": "workspace:*",
     "@unisat/keyring-service": "workspace:*",
     "@unisat/permission-service": "workspace:*",
     "@unisat/phishing-detect": "workspace:*",

--- a/apps/extension/src/_locales/en/messages.json
+++ b/apps/extension/src/_locales/en/messages.json
@@ -795,7 +795,7 @@
     "message": "Import Descriptor"
   },
   "import_descriptor_help": {
-    "message": "Paste a watch-only singlesig descriptor (wpkh / tr / sh(wpkh)). Checksum (#…) required."
+    "message": "Paste a watch-only singlesig descriptor (wpkh / tr / sh(wpkh)). Checksum (#…) required. Sparrow multipath (/<0;1>/*) is accepted and expanded to receive + change."
   },
   "import_descriptor_watch_only_note": {
     "message": "Imports as Watch Address: balances/inscriptions can show; signing is disabled. Private xprv descriptors are rejected."
@@ -825,13 +825,13 @@
     "message": "No master fingerprint in QR — descriptor export will omit [fingerprint/path] origin."
   },
 "import_descriptor_gap_note": {
-    "message": "Stores the descriptor so you can add more receive addresses later (gap discovery). v1 indexes the receive chain (0/*); change (1/*) is stored for export when the paste is a standard receive descriptor. Initial scan size:"
+    "message": "Stores the descriptor so you can add more receive addresses later (gap discovery). v1 indexes the receive chain (0/*); change (1/*) is stored for export when the paste is /0/* or Sparrow /<0;1>/*. Initial scan size:"
   },
   "import_descriptor_wallet_name": {
     "message": "Wallet name (optional)"
   },
   "import_descriptor_placeholder": {
-    "message": "wpkh([fpr/84h/0h/0h]xpub…/0/*)#checksum"
+    "message": "wpkh([fpr/84h/0h/0h]xpub…/0/*)#checksum or …/<0;1>/*)#…"
   },
   "import_descriptor_button": {
     "message": "Import watch-only"
@@ -2637,7 +2637,10 @@
   "utxo_indexing_risk_title": {
     "message": "UTXO Indexing in Progress"
   },
-  "utxo_not_found": {
+    "utxo": {
+    "message": "UTXO"
+  },
+"utxo_not_found": {
     "message": "UTXO not found."
   },
   "verify_recovery_phrase": {

--- a/apps/extension/src/_locales/en/messages.json
+++ b/apps/extension/src/_locales/en/messages.json
@@ -570,7 +570,13 @@
     "message": "Create Watch Wallet"
   },
   "create_with_mnemonics_12words": {
-    "message": "Create with mnemonics (12-words)"
+    "message": "Create with mnemonics (12 or 24 words)"
+  },
+  "confirm_backup_by_selecting_words": {
+    "message": "Select the correct word for each numbered position to confirm your backup (you do not need to enter the full phrase)."
+  },
+  "word_number": {
+    "message": "Word #$1"
   },
   "current": {
     "message": "Current"
@@ -755,6 +761,91 @@
   "export_private_key": {
     "message": "Export Private Key"
   },
+  "export_descriptor_xpub": {
+    "message": "Export descriptor / xpub"
+  },
+  "export_descriptor_title": {
+    "message": "Export descriptor / xpub"
+  },
+  "export_descriptor_help": {
+    "message": "Watch-only export. Prefer descriptors for Sparrow (path + script type + checksum). Account xpub is also available. Never includes private keys or xprv."
+  },
+  "export_descriptor_policy": {
+    "message": "Policy: $1"
+  },
+  "export_descriptor_receive": {
+    "message": "Receive descriptor (0/*)"
+  },
+  "export_descriptor_change": {
+    "message": "Change descriptor (1/*)"
+  },
+  "export_descriptor_account_xpub": {
+    "message": "Account xpub"
+  },
+  "export_descriptor_copy_receive": {
+    "message": "Copy receive descriptor"
+  },
+  "export_descriptor_copy_xpub": {
+    "message": "Copy account xpub"
+  },
+  "import_descriptor": {
+    "message": "Import descriptor"
+  },
+  "import_descriptor_title": {
+    "message": "Import Descriptor"
+  },
+  "import_descriptor_help": {
+    "message": "Paste a watch-only singlesig descriptor (wpkh / tr / sh(wpkh)). Checksum (#…) required."
+  },
+  "import_descriptor_watch_only_note": {
+    "message": "Imports as Watch Address: balances/inscriptions can show; signing is disabled. Private xprv descriptors are rejected."
+  },
+  "watch_only": {
+    "message": "Watch only"
+  },
+    "import_descriptor_preview": {
+    "message": "Check addresses"
+  },
+  "import_descriptor_confirm_title": {
+    "message": "Confirm watch-only addresses"
+  },
+  "import_descriptor_confirm_note": {
+    "message": "Anyone who gave you this descriptor controls these addresses. Confirm #0 matches the source wallet before importing."
+  },
+  "import_descriptor_confirm_button": {
+    "message": "Import watch-only wallet"
+  },
+  "cold_wallet_fingerprint": {
+    "message": "Fingerprint"
+  },
+  "cold_wallet_fingerprint_verify": {
+    "message": "Verify this fingerprint on your cold device before continuing."
+  },
+  "cold_wallet_fingerprint_omitted": {
+    "message": "No master fingerprint in QR — descriptor export will omit [fingerprint/path] origin."
+  },
+"import_descriptor_gap_note": {
+    "message": "Stores the descriptor so you can add more receive addresses later (gap discovery). v1 indexes the receive chain (0/*); change (1/*) is stored for export when the paste is a standard receive descriptor. Initial scan size:"
+  },
+  "import_descriptor_wallet_name": {
+    "message": "Wallet name (optional)"
+  },
+  "import_descriptor_placeholder": {
+    "message": "wpkh([fpr/84h/0h/0h]xpub…/0/*)#checksum"
+  },
+  "import_descriptor_button": {
+    "message": "Import watch-only"
+  },
+  "import_descriptor_gap_20": {
+    "message": "20 addresses"
+  },
+  "import_descriptor_gap_50": {
+    "message": "50 addresses"
+  },
+  "import_descriptor_gap_100": {
+    "message": "100 addresses"
+  },
+
   "failed_to_delete_contact": {
     "message": "Failed to delete contact"
   },

--- a/apps/extension/src/shared/initPlatformEnv.ts
+++ b/apps/extension/src/shared/initPlatformEnv.ts
@@ -1,9 +1,14 @@
 import { PlatformEnv } from '@unisat/wallet-shared';
 
-PlatformEnv.VERSION = process.env.release!;
-PlatformEnv.CHANNEL = process.env.channel!;
+/** Webpack DefinePlugin injects these; fall back so a bad local build cannot crash connect/UI. */
+const release = typeof process.env.release === 'string' && process.env.release ? process.env.release : '1.7.17';
+const channel = typeof process.env.channel === 'string' && process.env.channel ? process.env.channel : 'github';
+const manifest = typeof process.env.manifest === 'string' && process.env.manifest ? process.env.manifest : 'mv3';
+
+PlatformEnv.VERSION = release;
+PlatformEnv.CHANNEL = channel;
 PlatformEnv.PLATFORM = 'extension';
-PlatformEnv.MANIFEST_VERSION = process.env.manifest!;
+PlatformEnv.MANIFEST_VERSION = manifest;
 PlatformEnv.REVIEW_URL =
   'https://chromewebstore.google.com/detail/unisat-wallet/ppbibelpcjmhbdihakflkdcoccbgbkpo/reviews';
 

--- a/apps/extension/src/ui/components/Input/TextInput.tsx
+++ b/apps/extension/src/ui/components/Input/TextInput.tsx
@@ -1,8 +1,39 @@
 import { colors } from '@/ui/theme/colors';
-import { $baseContainerStyle, $baseInputStyle, InputProps } from '.';
+import { $baseContainerStyle, $baseInputStyle, $baseTextareaStyle, InputProps } from '.';
 
 export function TextInput(props: InputProps) {
-  const { placeholder, containerStyle, style: $inputStyleOverride, disabled, autoFocus, maxLength, ...rest } = props;
+  const {
+    placeholder,
+    containerStyle,
+    style: $inputStyleOverride,
+    disabled,
+    autoFocus,
+    maxLength,
+    rows,
+    ...rest
+  } = props;
+  // Multiline for long pastes (e.g. BIP-380 descriptors); single-line input truncates UX.
+  if (typeof rows === 'number' && rows > 1) {
+    return (
+      <div
+        style={Object.assign({}, $baseContainerStyle, { alignItems: 'flex-start' }, containerStyle)}>
+        <textarea
+          placeholder={placeholder}
+          disabled={disabled}
+          autoFocus={autoFocus}
+          maxLength={maxLength}
+          rows={rows}
+          style={Object.assign(
+            {},
+            $baseTextareaStyle,
+            $inputStyleOverride,
+            disabled ? { color: colors.textDim } : {}
+          )}
+          {...rest}
+        />
+      </div>
+    );
+  }
   return (
     <div style={Object.assign({}, $baseContainerStyle, containerStyle)}>
       <input

--- a/apps/extension/src/ui/components/Input/index.tsx
+++ b/apps/extension/src/ui/components/Input/index.tsx
@@ -43,6 +43,8 @@ export interface InputProps {
   autoComplete?: string;
   spellCheck?: boolean;
   inputMode?: React.HTMLAttributes<HTMLInputElement>['inputMode'];
+  /** When > 1, TextInput renders a textarea (long pastes / descriptors). */
+  rows?: number;
   enableStepper?: boolean;
   step?: number;
   min?: number;

--- a/apps/extension/src/ui/pages/Account/AddKeyringScreen.tsx
+++ b/apps/extension/src/ui/pages/Account/AddKeyringScreen.tsx
@@ -24,7 +24,7 @@ export default function AddKeyringScreen() {
             }}
             data-testid="create-wallet-with-mnemonics-option">
             <Column full justifyCenter>
-              <Text text={t('create_with_mnemonics_12words')} size="sm" />
+              <Text text={t('create_with_mnemonics_12words') || 'Create with mnemonics (12 or 24 words)'} size="sm" />
             </Column>
           </Card>
 

--- a/apps/extension/src/ui/pages/Account/CreateColdWalletScreen/components/Step2.tsx
+++ b/apps/extension/src/ui/pages/Account/CreateColdWalletScreen/components/Step2.tsx
@@ -55,7 +55,14 @@ export default function Step2({ onBack, onNext }: Step2Props) {
         throw new Error('Account count must be between 1 and 20');
       }
 
-      return coldWalletData as ContextData;
+      const rawFpr =
+        coldWalletData.fingerprint || coldWalletData.masterFingerprint || coldWalletData.mfp || '';
+      const fingerprint =
+        typeof rawFpr === 'string' && /^[0-9a-fA-F]{8}$/.test(rawFpr.replace(/^0x/, ''))
+          ? rawFpr.replace(/^0x/, '').toLowerCase()
+          : undefined;
+
+      return { ...(coldWalletData as ContextData), fingerprint };
     },
     []
   );

--- a/apps/extension/src/ui/pages/Account/CreateColdWalletScreen/components/Step3.tsx
+++ b/apps/extension/src/ui/pages/Account/CreateColdWalletScreen/components/Step3.tsx
@@ -135,7 +135,14 @@ export default function Step3({ onBack, contextData }: Step3Props) {
       tools.showLoading(true);
       const walletName = contextData.walletName || 'Cold Wallet';
       const accountCount = contextData.accountCount || displayCount;
-      await createColdWallet(contextData.xpub, addressType, walletName, contextData.hdPath, accountCount);
+      await createColdWallet(
+        contextData.xpub,
+        addressType,
+        walletName,
+        contextData.hdPath,
+        accountCount,
+        contextData.fingerprint
+      );
 
       navigate('MainScreen');
     } catch (e) {
@@ -157,6 +164,37 @@ export default function Step3({ onBack, contextData }: Step3Props) {
             textCenter
             style={{ marginBottom: '16px', lineHeight: '20px' }}
           />
+
+          {contextData.fingerprint ? (
+            <Column gap="xs" style={{ marginBottom: 12 }}>
+              <Text
+                text={`${t('cold_wallet_fingerprint') || 'Fingerprint'}: ${contextData.fingerprint}`}
+                size="sm"
+                color="gold"
+                textCenter
+              />
+              <Text
+                text={
+                  t('cold_wallet_fingerprint_verify') ||
+                  'Verify this fingerprint on your cold device before continuing.'
+                }
+                preset="sub"
+                size="xs"
+                textCenter
+              />
+            </Column>
+          ) : (
+            <Text
+              text={
+                t('cold_wallet_fingerprint_omitted') ||
+                'No master fingerprint in QR — descriptor export will omit [fingerprint/path] origin.'
+              }
+              preset="sub"
+              size="xs"
+              textCenter
+              style={{ marginBottom: 12 }}
+            />
+          )}
 
           <Row justifyBetween itemsCenter style={{ marginBottom: '8px' }}>
             <Row itemsCenter gap="sm">

--- a/apps/extension/src/ui/pages/Account/CreateColdWalletScreen/types.ts
+++ b/apps/extension/src/ui/pages/Account/CreateColdWalletScreen/types.ts
@@ -8,6 +8,8 @@ export interface ContextData {
   walletName?: string;
   hdPath?: string;
   accountCount?: number;
+  /** Optional 8-hex master fingerprint from cold QR when provided */
+  fingerprint?: string;
 }
 
 // Component props interfaces

--- a/apps/extension/src/ui/pages/Account/SwitchAccountScreen.tsx
+++ b/apps/extension/src/ui/pages/Account/SwitchAccountScreen.tsx
@@ -1,5 +1,5 @@
-import VirtualList, { ListRef } from 'rc-virtual-list';
-import { forwardRef, useEffect, useMemo, useRef, useState } from 'react';
+import VirtualList from 'rc-virtual-list';
+import { forwardRef, useMemo, useState } from 'react';
 
 import { Card, Column, Content, Header, Icon, Layout, Row, Text } from '@/ui/components';
 import { colors } from '@/ui/theme/colors';
@@ -189,25 +189,11 @@ export default function SwitchAccountScreen() {
     }
 
     return _items;
-  }, []);
-
-  const currentAccount = useCurrentAccount();
-  const currentIndex = keyring.accounts.findIndex((v) => v.pubkey == currentAccount.pubkey);
+  }, [keyring.accounts]);
 
   const ForwardMyItem = forwardRef(MyItem);
-  const refList = useRef<ListRef>(null);
-
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      if (refList.current && currentIndex >= 0) {
-        refList.current?.scrollTo({ key: currentAccount.address, align: 'top' });
-      }
-    });
-
-    return () => clearTimeout(timeoutId);
-  }, []);
-
   const layoutHeight = Math.ceil((window.innerHeight - 64) / ITEM_HEIGHT) * ITEM_HEIGHT;
+  // No auto scrollTo — avoids rc-virtual-list "max limitation" warning.
   const canCreateAccount = ACCOUNT_CREATABLE_KEYRING_TYPES.includes(keyring.type as KeyringType);
 
   return (
@@ -237,7 +223,6 @@ export default function SwitchAccountScreen() {
           height={layoutHeight}
           itemHeight={ITEM_HEIGHT}
           itemKey={(item) => item.key}
-          ref={refList}
         >
           {(item, index) => <ForwardMyItem account={item.account} autoNav={true} />}
         </VirtualList>

--- a/apps/extension/src/ui/pages/Account/SwitchKeyringScreen.tsx
+++ b/apps/extension/src/ui/pages/Account/SwitchKeyringScreen.tsx
@@ -1,5 +1,5 @@
-import VirtualList, { ListRef } from 'rc-virtual-list';
-import { forwardRef, useEffect, useMemo, useRef, useState } from 'react';
+import VirtualList from 'rc-virtual-list';
+import { forwardRef, useMemo, useState } from 'react';
 
 import { Card, Column, Content, Header, Icon, Layout, Row, Text } from '@/ui/components';
 import { RemoveWalletPopover } from '@/ui/components/RemoveWalletPopover';
@@ -245,7 +245,6 @@ export default function SwitchKeyringScreen() {
   const { t } = useI18n();
 
   const ForwardMyItem = forwardRef(MyItem);
-  const refList = useRef<ListRef>(null);
 
   const items = useMemo(() => {
     const _items: ItemData[] = keyrings.map((v) => {
@@ -264,20 +263,9 @@ export default function SwitchKeyringScreen() {
     return _items;
   }, [keyrings]);
 
-  const currentKeyring = useCurrentKeyring();
-  const currentIndex = keyrings.findIndex((v) => v.key == currentKeyring.key);
-
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      if (refList.current && currentIndex >= 0) {
-        refList.current?.scrollTo({ index: currentIndex, align: 'top' });
-      }
-    });
-
-    return () => clearTimeout(timeoutId);
-  }, []);
-
   const layoutHeight = Math.ceil((window.innerHeight - 64) / ITEM_HEIGHT) * ITEM_HEIGHT;
+  // Do not auto scrollTo — rc-virtual-list warns when content fits the viewport
+  // ("reach the max limitation"). List order is fine without it.
 
   return (
     <Layout>
@@ -299,7 +287,6 @@ export default function SwitchKeyringScreen() {
       />
       <Content style={{ padding: 5 }}>
         <VirtualList
-          ref={refList}
           data={items}
           data-id="list"
           height={layoutHeight}

--- a/apps/extension/src/ui/pages/Account/createHDWalletComponents/Step1_Confirm.tsx
+++ b/apps/extension/src/ui/pages/Account/createHDWalletComponents/Step1_Confirm.tsx
@@ -1,3 +1,4 @@
+import { wordlists } from 'bip39';
 import { useEffect, useMemo, useState } from 'react';
 
 import { Button, Card, Column, Grid, Row, Text } from '@/ui/components';
@@ -6,16 +7,42 @@ import { ContextData, TabType, UpdateContextDataParams } from '@/ui/pages/Accoun
 import { colors } from '@/ui/theme/colors';
 import { useI18n } from '@unisat/wallet-state';
 
-/** Industry practice: verify a few random positions, not the full phrase (MetaMask / Bitnob / VP0). */
+/**
+ * Production backup confirmation (create-wallet path).
+ * - Challenge a few random positions (not the full phrase on-screen again).
+ * - Correct answers matched by phrase index (duplicate BIP-39 words cannot bypass).
+ * - Distractors from the English BIP-39 wordlist, never other words from this seed.
+ * - Seed for keyring creation remains in encrypted preMnemonics; UI clears the phrase after verify.
+ */
 const CHALLENGE_COUNT = 3;
 const DISTRACTOR_COUNT = 5;
+const ENGLISH = wordlists.english;
+
+type Choice = {
+  id: string;
+  word: string;
+  /** Phrase index when this is the correct word for a challenge; null = distractor */
+  phraseIndex: number | null;
+};
+
+/** Unbiased int in [0, maxExclusive). */
+function cryptoRandomInt(maxExclusive: number): number {
+  if (maxExclusive <= 0) throw new Error('maxExclusive must be positive');
+  const maxUint = 0x100000000;
+  const limit = maxUint - (maxUint % maxExclusive);
+  const buf = new Uint32Array(1);
+  let x: number;
+  do {
+    crypto.getRandomValues(buf);
+    x = buf[0]!;
+  } while (x >= limit);
+  return x % maxExclusive;
+}
 
 function cryptoShuffle<T>(items: T[]): T[] {
   const arr = [...items];
   for (let index = arr.length - 1; index > 0; index--) {
-    const random = new Uint32Array(1);
-    crypto.getRandomValues(random);
-    const swapIndex = random[0]! % (index + 1);
+    const swapIndex = cryptoRandomInt(index + 1);
     [arr[index], arr[swapIndex]] = [arr[swapIndex]!, arr[index]!];
   }
   return arr;
@@ -28,6 +55,41 @@ function pickChallengePositions(wordCount: number, count: number): number[] {
     .sort((a, b) => a - b);
 }
 
+function pickWordlistDistractors(phraseWords: string[], count: number): string[] {
+  const banned = new Set(phraseWords);
+  const pool: string[] = [];
+  for (const w of ENGLISH) {
+    if (!banned.has(w)) pool.push(w);
+  }
+  if (pool.length < count) {
+    throw new Error('BIP-39 wordlist too small for distractors');
+  }
+  const picked: string[] = [];
+  // sample without replacement
+  for (let i = 0; i < count; i++) {
+    const idx = cryptoRandomInt(pool.length - i);
+    const last = pool.length - 1 - i;
+    const word = pool[idx]!;
+    pool[idx] = pool[last]!;
+    picked.push(word);
+  }
+  return picked;
+}
+
+function buildChoices(words: string[], challenges: number[]): Choice[] {
+  const correct: Choice[] = challenges.map((phraseIndex) => ({
+    id: `c-${phraseIndex}`,
+    word: words[phraseIndex]!,
+    phraseIndex
+  }));
+  const distractors: Choice[] = pickWordlistDistractors(words, DISTRACTOR_COUNT).map((word, i) => ({
+    id: `d-${i}-${word}`,
+    word,
+    phraseIndex: null
+  }));
+  return cryptoShuffle([...correct, ...distractors]);
+}
+
 export function Step1_Confirm({
   contextData,
   updateContextData
@@ -36,55 +98,75 @@ export function Step1_Confirm({
   updateContextData: (params: UpdateContextDataParams) => void;
 }) {
   const { t } = useI18n();
-  const words = useMemo(() => contextData.mnemonics.split(' ').filter(Boolean), [contextData.mnemonics]);
+  const words = useMemo(() => contextData.mnemonics.split(/\s+/).filter(Boolean), [contextData.mnemonics]);
 
-  const challenges = useMemo(() => pickChallengePositions(words.length, CHALLENGE_COUNT), [words, contextData.mnemonics]);
+  const challenges = useMemo(
+    () => (words.length ? pickChallengePositions(words.length, CHALLENGE_COUNT) : []),
+    // regenerate only when the seed string changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [contextData.mnemonics]
+  );
 
   const choices = useMemo(() => {
-    if (!words.length || !challenges.length) return [] as number[];
-    const challengeSet = new Set(challenges);
-    const distractors = cryptoShuffle(Array.from({ length: words.length }, (_, i) => i).filter((i) => !challengeSet.has(i))).slice(
-      0,
-      DISTRACTOR_COUNT
-    );
-    return cryptoShuffle([...challenges, ...distractors]);
-  }, [words, challenges, contextData.mnemonics]);
-
-  // selectedWordIndex per challenge slot (parallel to challenges[])
-  const [selectedIndexes, setSelectedIndexes] = useState<(number | undefined)[]>([]);
-
-  useEffect(() => {
-    setSelectedIndexes(challenges.map(() => undefined));
+    if (!words.length || !challenges.length) return [] as Choice[];
+    return buildChoices(words, challenges);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contextData.mnemonics, challenges]);
 
-  const activeSlot = selectedIndexes.findIndex((v) => v === undefined);
+  // selected choice id per challenge slot
+  const [selectedIds, setSelectedIds] = useState<(string | undefined)[]>([]);
 
-  // Require the exact challenge index (not merely matching word text — duplicates could bypass)
-  const hasIncorrectSelection = selectedIndexes.some(
-    (wordIndex, slot) => wordIndex !== undefined && wordIndex !== challenges[slot]
-  );
+  useEffect(() => {
+    setSelectedIds(challenges.map(() => undefined));
+  }, [contextData.mnemonics, challenges]);
+
+  const choiceById = useMemo(() => {
+    const map = new Map<string, Choice>();
+    for (const c of choices) map.set(c.id, c);
+    return map;
+  }, [choices]);
+
+  const activeSlot = selectedIds.findIndex((v) => v === undefined);
+
+  const slotIsIncorrect = (slot: number): boolean => {
+    const id = selectedIds[slot];
+    if (id === undefined) return false;
+    const choice = choiceById.get(id);
+    return !choice || choice.phraseIndex !== challenges[slot];
+  };
+
+  const hasIncorrectSelection = challenges.some((_, slot) => slotIsIncorrect(slot));
+
   const isVerified =
-    selectedIndexes.length === challenges.length &&
-    selectedIndexes.every((wordIndex, slot) => wordIndex !== undefined && wordIndex === challenges[slot]) &&
+    challenges.length > 0 &&
+    selectedIds.length === challenges.length &&
+    selectedIds.every((id, slot) => {
+      if (id === undefined) return false;
+      const choice = choiceById.get(id);
+      return choice?.phraseIndex === challenges[slot];
+    }) &&
     !hasIncorrectSelection;
 
-  const onSelect = (wordIndex: number) => {
-    setSelectedIndexes((current) => {
-      // deselect if already chosen
-      const existingSlot = current.indexOf(wordIndex);
+  const onSelectChoice = (choiceId: string) => {
+    setSelectedIds((current) => {
+      const existingSlot = current.indexOf(choiceId);
       if (existingSlot >= 0) {
         const next = [...current];
         next[existingSlot] = undefined;
         return next;
       }
-      // block further picks while an incorrect answer is showing
-      if (current.some((selectedWordIndex, slot) => selectedWordIndex !== undefined && selectedWordIndex !== challenges[slot])) {
+      if (current.some((_, slot) => {
+        const id = current[slot];
+        if (id === undefined) return false;
+        const choice = choiceById.get(id);
+        return !choice || choice.phraseIndex !== challenges[slot];
+      })) {
         return current;
       }
       const slot = current.findIndex((v) => v === undefined);
       if (slot < 0) return current;
       const next = [...current];
-      next[slot] = wordIndex;
+      next[slot] = choiceId;
       return next;
     });
   };
@@ -93,7 +175,10 @@ export function Step1_Confirm({
     <Column gap="lg">
       <Text text={t('verify_recovery_phrase')} preset="title-bold" textCenter />
       <Text
-        text={t('confirm_backup_by_selecting_words') || 'Select the correct word for each position to confirm your backup.'}
+        text={
+          t('confirm_backup_by_selecting_words') ||
+          'Select the correct word for each numbered position to confirm your backup.'
+        }
         preset="sub"
         color="textDim"
         textCenter
@@ -102,9 +187,10 @@ export function Step1_Confirm({
 
       <Grid columns={1} gap="sm" style={{ width: '100%' }}>
         {challenges.map((wordPos, slot) => {
-          const selectedWordIndex = selectedIndexes[slot];
-          const isIncorrect = selectedWordIndex !== undefined && selectedWordIndex !== wordPos;
-          const isSelected = selectedWordIndex !== undefined;
+          const selectedId = selectedIds[slot];
+          const selectedChoice = selectedId ? choiceById.get(selectedId) : undefined;
+          const isIncorrect = slotIsIncorrect(slot);
+          const isSelected = selectedId !== undefined;
           const isActive = slot === activeSlot;
 
           return (
@@ -112,7 +198,7 @@ export function Step1_Confirm({
               key={wordPos}
               preset="style3"
               onClick={
-                isIncorrect && selectedWordIndex !== undefined ? () => onSelect(selectedWordIndex) : undefined
+                isIncorrect && selectedId !== undefined ? () => onSelectChoice(selectedId) : undefined
               }
               style={{
                 minHeight: 44,
@@ -141,7 +227,7 @@ export function Step1_Confirm({
                 color={isIncorrect ? 'error' : 'textDim'}
               />
               <Text
-                text={selectedWordIndex === undefined ? '...' : words[selectedWordIndex]!}
+                text={selectedChoice ? selectedChoice.word : '...'}
                 size="sm"
                 ellipsis
                 color={isIncorrect ? 'error' : isSelected ? 'primary' : undefined}
@@ -154,16 +240,16 @@ export function Step1_Confirm({
 
       <Row justifyCenter fullX>
         <Grid columns={3} gap="sm" style={{ width: '100%' }}>
-          {choices.map((wordIndex) => {
-            const slotIndex = selectedIndexes.indexOf(wordIndex);
-            const isIncorrect = slotIndex >= 0 && wordIndex !== challenges[slotIndex];
+          {choices.map((choice) => {
+            const slotIndex = selectedIds.indexOf(choice.id);
             const isSelected = slotIndex >= 0;
+            const isIncorrect = isSelected && choice.phraseIndex !== challenges[slotIndex];
 
             return (
               <Button
-                key={wordIndex}
+                key={choice.id}
                 preset="defaultV2"
-                onClick={isSelected && !isIncorrect ? undefined : () => onSelect(wordIndex)}
+                onClick={isSelected && !isIncorrect ? undefined : () => onSelectChoice(choice.id)}
                 style={{
                   minHeight: 40,
                   borderRadius: 6,
@@ -177,9 +263,9 @@ export function Step1_Confirm({
                       : '#151313',
                   cursor: isSelected && !isIncorrect ? 'default' : 'pointer'
                 }}
-                data-testid={`mnemonic-confirm-word-${wordIndex}`}>
+                data-testid={`mnemonic-confirm-choice-${choice.id}`}>
                 <Text
-                  text={words[wordIndex]!}
+                  text={choice.word}
                   size="sm"
                   color={isIncorrect ? 'error' : isSelected ? 'primary' : undefined}
                   disableTranslate
@@ -197,6 +283,7 @@ export function Step1_Confirm({
           text={t('continue')}
           preset="primary"
           onClick={() =>
+            // Drop phrase from React state; keyring create uses encrypted preMnemonics in background.
             updateContextData({ mnemonics: '', mnemonicVerified: true, tabType: TabType.CHOOSE_ADDRESS_TYPE })
           }
           data-testid="mnemonic-confirm-continue-button"

--- a/apps/extension/src/ui/pages/Account/createHDWalletComponents/Step1_Confirm.tsx
+++ b/apps/extension/src/ui/pages/Account/createHDWalletComponents/Step1_Confirm.tsx
@@ -2,21 +2,30 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { Button, Card, Column, Grid, Row, Text } from '@/ui/components';
 import { FooterButtonContainer } from '@/ui/components/FooterButtonContainer';
-import { colors } from '@/ui/theme/colors';
 import { ContextData, TabType, UpdateContextDataParams } from '@/ui/pages/Account/createHDWalletComponents/types';
+import { colors } from '@/ui/theme/colors';
 import { useI18n } from '@unisat/wallet-state';
 
-function shuffledIndexes(length: number): number[] {
-  const indexes = Array.from({ length }, (_, index) => index);
+/** Industry practice: verify a few random positions, not the full phrase (MetaMask / Bitnob / VP0). */
+const CHALLENGE_COUNT = 3;
+const DISTRACTOR_COUNT = 5;
 
-  for (let index = indexes.length - 1; index > 0; index--) {
+function cryptoShuffle<T>(items: T[]): T[] {
+  const arr = [...items];
+  for (let index = arr.length - 1; index > 0; index--) {
     const random = new Uint32Array(1);
     crypto.getRandomValues(random);
     const swapIndex = random[0]! % (index + 1);
-    [indexes[index], indexes[swapIndex]] = [indexes[swapIndex]!, indexes[index]!];
+    [arr[index], arr[swapIndex]] = [arr[swapIndex]!, arr[index]!];
   }
+  return arr;
+}
 
-  return indexes;
+function pickChallengePositions(wordCount: number, count: number): number[] {
+  const all = Array.from({ length: wordCount }, (_, i) => i);
+  return cryptoShuffle(all)
+    .slice(0, Math.min(count, wordCount))
+    .sort((a, b) => a - b);
 }
 
 export function Step1_Confirm({
@@ -28,25 +37,55 @@ export function Step1_Confirm({
 }) {
   const { t } = useI18n();
   const words = useMemo(() => contextData.mnemonics.split(' ').filter(Boolean), [contextData.mnemonics]);
-  const choices = useMemo(() => shuffledIndexes(words.length), [words.length, contextData.mnemonics]);
-  const [selectedIndexes, setSelectedIndexes] = useState<number[]>([]);
+
+  const challenges = useMemo(() => pickChallengePositions(words.length, CHALLENGE_COUNT), [words, contextData.mnemonics]);
+
+  const choices = useMemo(() => {
+    if (!words.length || !challenges.length) return [] as number[];
+    const challengeSet = new Set(challenges);
+    const distractors = cryptoShuffle(Array.from({ length: words.length }, (_, i) => i).filter((i) => !challengeSet.has(i))).slice(
+      0,
+      DISTRACTOR_COUNT
+    );
+    return cryptoShuffle([...challenges, ...distractors]);
+  }, [words, challenges, contextData.mnemonics]);
+
+  // selectedWordIndex per challenge slot (parallel to challenges[])
+  const [selectedIndexes, setSelectedIndexes] = useState<(number | undefined)[]>([]);
 
   useEffect(() => {
-    setSelectedIndexes([]);
-  }, [contextData.mnemonics]);
+    setSelectedIndexes(challenges.map(() => undefined));
+  }, [contextData.mnemonics, challenges]);
 
-  const hasIncorrectSelection = selectedIndexes.some((wordIndex, slotIndex) => words[wordIndex] !== words[slotIndex]);
-  const isVerified = selectedIndexes.length === words.length && !hasIncorrectSelection;
+  const activeSlot = selectedIndexes.findIndex((v) => v === undefined);
+
+  // Require the exact challenge index (not merely matching word text — duplicates could bypass)
+  const hasIncorrectSelection = selectedIndexes.some(
+    (wordIndex, slot) => wordIndex !== undefined && wordIndex !== challenges[slot]
+  );
+  const isVerified =
+    selectedIndexes.length === challenges.length &&
+    selectedIndexes.every((wordIndex, slot) => wordIndex !== undefined && wordIndex === challenges[slot]) &&
+    !hasIncorrectSelection;
 
   const onSelect = (wordIndex: number) => {
     setSelectedIndexes((current) => {
-      if (current.includes(wordIndex)) {
-        return current.filter((index) => index !== wordIndex);
+      // deselect if already chosen
+      const existingSlot = current.indexOf(wordIndex);
+      if (existingSlot >= 0) {
+        const next = [...current];
+        next[existingSlot] = undefined;
+        return next;
       }
-      if (current.some((selectedWordIndex, slotIndex) => words[selectedWordIndex] !== words[slotIndex])) {
+      // block further picks while an incorrect answer is showing
+      if (current.some((selectedWordIndex, slot) => selectedWordIndex !== undefined && selectedWordIndex !== challenges[slot])) {
         return current;
       }
-      return [...current, wordIndex];
+      const slot = current.findIndex((v) => v === undefined);
+      if (slot < 0) return current;
+      const next = [...current];
+      next[slot] = wordIndex;
+      return next;
     });
   };
 
@@ -54,43 +93,56 @@ export function Step1_Confirm({
     <Column gap="lg">
       <Text text={t('verify_recovery_phrase')} preset="title-bold" textCenter />
       <Text
-        text={t('click_on_the_words_to_put_them_in_the_correct_orde')}
+        text={t('confirm_backup_by_selecting_words') || 'Select the correct word for each position to confirm your backup.'}
         preset="sub"
         color="textDim"
         textCenter
         style={{ maxWidth: 420, alignSelf: 'center', lineHeight: '18px' }}
       />
 
-      <Grid columns={3} gap="sm" style={{ width: '100%' }}>
-        {words.map((_, index) => {
-          const selectedWordIndex = selectedIndexes[index];
-          const isIncorrect = selectedWordIndex !== undefined && words[selectedWordIndex] !== words[index];
+      <Grid columns={1} gap="sm" style={{ width: '100%' }}>
+        {challenges.map((wordPos, slot) => {
+          const selectedWordIndex = selectedIndexes[slot];
+          const isIncorrect = selectedWordIndex !== undefined && selectedWordIndex !== wordPos;
           const isSelected = selectedWordIndex !== undefined;
+          const isActive = slot === activeSlot;
 
           return (
             <Card
-              key={index}
+              key={wordPos}
               preset="style3"
-              onClick={isIncorrect && selectedWordIndex !== undefined ? () => onSelect(selectedWordIndex) : undefined}
+              onClick={
+                isIncorrect && selectedWordIndex !== undefined ? () => onSelect(selectedWordIndex) : undefined
+              }
               style={{
-                minHeight: 40,
+                minHeight: 44,
                 justifyContent: 'flex-start',
-                padding: '0 10px',
-                gap: 6,
+                padding: '0 12px',
+                gap: 8,
                 borderWidth: 1,
-                borderColor: isIncorrect ? colors.error : isSelected ? 'rgba(227, 187, 95, 0.45)' : colors.border2,
+                borderColor: isIncorrect
+                  ? colors.error
+                  : isActive
+                    ? 'rgba(227, 187, 95, 0.65)'
+                    : isSelected
+                      ? 'rgba(227, 187, 95, 0.45)'
+                      : colors.border2,
                 backgroundColor: isIncorrect
                   ? 'rgba(229, 41, 55, 0.12)'
                   : isSelected
                     ? 'rgba(227, 187, 95, 0.08)'
                     : colors.card
               }}
-              data-testid={`mnemonic-confirm-slot-${index}`}
-            >
-              <Text text={`${index + 1}.`} size="xs" style={{ width: 20 }} color={isIncorrect ? 'error' : 'textDim'} />
+              data-testid={`mnemonic-confirm-slot-${wordPos}`}>
+              <Text
+                text={(t('word_number') || 'Word #$1').replace('$1', String(wordPos + 1))}
+                size="xs"
+                style={{ width: 72 }}
+                color={isIncorrect ? 'error' : 'textDim'}
+              />
               <Text
                 text={selectedWordIndex === undefined ? '...' : words[selectedWordIndex]!}
-                size="xs"
+                size="sm"
                 ellipsis
                 color={isIncorrect ? 'error' : isSelected ? 'primary' : undefined}
                 disableTranslate
@@ -104,7 +156,7 @@ export function Step1_Confirm({
         <Grid columns={3} gap="sm" style={{ width: '100%' }}>
           {choices.map((wordIndex) => {
             const slotIndex = selectedIndexes.indexOf(wordIndex);
-            const isIncorrect = slotIndex >= 0 && words[wordIndex] !== words[slotIndex];
+            const isIncorrect = slotIndex >= 0 && wordIndex !== challenges[slotIndex];
             const isSelected = slotIndex >= 0;
 
             return (
@@ -125,8 +177,7 @@ export function Step1_Confirm({
                       : '#151313',
                   cursor: isSelected && !isIncorrect ? 'default' : 'pointer'
                 }}
-                data-testid={`mnemonic-confirm-word-${wordIndex}`}
-              >
+                data-testid={`mnemonic-confirm-word-${wordIndex}`}>
                 <Text
                   text={words[wordIndex]!}
                   size="sm"

--- a/apps/extension/src/ui/pages/Approval/components/SignPsbt/components/PolicyChip.tsx
+++ b/apps/extension/src/ui/pages/Approval/components/SignPsbt/components/PolicyChip.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+import { Row, Text } from '@/ui/components';
+import { useCurrentAccount, useWallet } from '@unisat/wallet-state';
+
+/** Shows BIP-380 policy summary for the current account on SignPsbt. */
+export function PolicyChip() {
+  const wallet = useWallet();
+  const currentAccount = useCurrentAccount();
+  const [label, setLabel] = useState<string>('');
+  const [complex, setComplex] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    wallet
+      .getAccountPolicySummary()
+      .then((policy: { label?: string; isComplex?: boolean }) => {
+        if (cancelled) return;
+        setLabel(policy?.label || '');
+        setComplex(Boolean(policy?.isComplex));
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setLabel('');
+          setComplex(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [wallet, currentAccount?.key, currentAccount?.address]);
+
+  if (!label) return null;
+
+  return (
+    <Row
+      itemsCenter
+      style={{
+        alignSelf: 'flex-start',
+        padding: '4px 10px',
+        borderRadius: 6,
+        background: 'rgba(255, 200, 87, 0.12)',
+        border: '1px solid rgba(255, 200, 87, 0.35)'
+      }}
+    >
+      <Text text={label} size="xs" color="gold" />
+      {complex ? <Text text="· advanced" size="xs" color="orange" /> : null}
+    </Row>
+  );
+}

--- a/apps/extension/src/ui/pages/Approval/components/SignPsbt/index.tsx
+++ b/apps/extension/src/ui/pages/Approval/components/SignPsbt/index.tsx
@@ -29,6 +29,7 @@ import AssetOverviewSection from './components/AssetOverviewSection';
 import { InputsList } from './components/InputsList';
 import MultiSignDisclaimerModal from './components/MultiSignDisclaimerModal';
 import { OutputsList } from './components/OutputsList';
+import { PolicyChip } from './components/PolicyChip';
 import PsbtDataSection from './components/PsbtDataSection';
 import { SignPsbtSection } from './components/Section';
 import { getIncrementalListResetKey } from './components/useIncrementalList';
@@ -298,6 +299,8 @@ export default function SignPsbt(props: SignPsbtProps) {
       {header}
       <Content>
         <Column gap="xl">
+          <PolicyChip />
+
           <ActionOverviewSection decodedPsbt={currentDecodedPsbt} action={currentToSignData.action!} />
 
           <AssetOverviewSection

--- a/apps/extension/src/ui/pages/Main/WalletTabScreen/components/BalanceCard.tsx
+++ b/apps/extension/src/ui/pages/Main/WalletTabScreen/components/BalanceCard.tsx
@@ -2,9 +2,33 @@ import { Column, Icon, Image, Row, Text, Tooltip } from '@/ui/components';
 import { BtcUsd } from '@/ui/components/BtcUsd';
 import { RefreshButton } from '@/ui/components/RefreshButton';
 import { fontSizes } from '@/ui/theme/font';
-import { useBalanceCardLogic } from '@unisat/wallet-state';
+import { KeyringType } from '@unisat/keyring-service/types';
+import { useBalanceCardLogic, useCurrentKeyring } from '@unisat/wallet-state';
 
 import { BtcDisplay } from './BtcDisplay';
+
+const GOLD_THEME = {
+  background: 'linear-gradient(117deg, #ffda8d 1.38%, #bf630f 94.19%)',
+  expanded: '#F1CC9F',
+  divider: 'rgba(109, 65, 0, 0.15)',
+  label: 'rgba(0,0,0,0.55)',
+  icon: 'black_muted' as const,
+  usd: 'black_muted' as const,
+  detailLabel: 'black_65' as const,
+  variant: 'gold' as const
+};
+
+/** Premium grey for watch-only — read-only tracker, not a spendable vault card */
+const WATCH_GREY_THEME = {
+  background: 'linear-gradient(125deg, #4a4a4e 0%, #2c2c30 48%, #1a1a1c 100%)',
+  expanded: '#2a2a2e',
+  divider: 'rgba(255, 255, 255, 0.12)',
+  label: 'rgba(255,255,255,0.55)',
+  icon: 'white_muted2' as const,
+  usd: 'white_muted2' as const,
+  detailLabel: 'white_muted2' as const,
+  variant: 'grey' as const
+};
 
 export function BalanceCard() {
   const {
@@ -29,6 +53,10 @@ export function BalanceCard() {
     refreshBalance
   } = useBalanceCardLogic();
 
+  const currentKeyring = useCurrentKeyring();
+  const isWatchOnly = currentKeyring?.type === KeyringType.WatchAddressKeyring;
+  const theme = isWatchOnly ? WATCH_GREY_THEME : GOLD_THEME;
+
   const backgroundImage = chain.isFractal
     ? './images/icons/artifacts/balance-bg-fb.png'
     : './images/icons/artifacts/balance-bg-btc.png';
@@ -40,18 +68,32 @@ export function BalanceCard() {
   return (
     <Column
       style={{
-        background: 'linear-gradient(117deg, #ffda8d 1.38%, #bf630f 94.19%)',
+        background: theme.background,
         borderRadius: 16,
         padding: 8,
-        position: 'relative'
+        position: 'relative',
+        boxShadow: isWatchOnly ? 'inset 0 1px 0 rgba(255,255,255,0.08)' : undefined
       }}
       onClick={() => {
         handleExpandToggle();
       }}>
       <Column style={{ padding: 8 }} gap={'md'}>
-        <Image src={backgroundImage} size={64} style={{ position: 'absolute', top: 0, right: 0 }} />
+        <Image
+          src={backgroundImage}
+          size={64}
+          style={{
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            opacity: isWatchOnly ? 0.35 : 1,
+            filter: isWatchOnly ? 'grayscale(1) brightness(1.4)' : undefined
+          }}
+        />
         <Row itemsCenter>
-          <Text size="sm" text={t('total_balance')} style={{ color: 'rgba(0,0,0,0.55)' }} />
+          <Text size="sm" text={t('total_balance')} style={{ color: theme.label }} />
+          {isWatchOnly ? (
+            <Text size="xs" text={t('watch_only') || 'Watch only'} style={{ color: theme.label, marginLeft: 6 }} />
+          ) : null}
           <Row itemsCenter gap="sm">
             <Row
               style={{ padding: 6, margin: -6 }}
@@ -59,19 +101,19 @@ export function BalanceCard() {
                 stopCardToggle(event);
                 handleHiddenToggle();
               }}>
-              <Icon color={'black_muted'} icon={isBalanceHidden ? 'balance-eyes-closed' : 'balance-eyes'} size={20} />
+              <Icon color={theme.icon} icon={isBalanceHidden ? 'balance-eyes-closed' : 'balance-eyes'} size={20} />
             </Row>
             <RefreshButton onClick={refreshBalance as any} hideText />
           </Row>
         </Row>
 
         <Row itemsCenter>
-          <BtcDisplay balance={balanceValue} hideBalance={isBalanceHidden} />
-          <Icon color={'black_muted'} size={16} icon={isDetailExpanded ? 'up' : 'down'} />
+          <BtcDisplay balance={balanceValue} hideBalance={isBalanceHidden} variant={theme.variant} />
+          <Icon color={theme.icon} size={16} icon={isDetailExpanded ? 'up' : 'down'} />
         </Row>
 
         {isCurrentChainBalance && (
-          <BtcUsd color={'black_muted'} sats={totalBalance} size={'md'} hideBalance={isBalanceHidden} />
+          <BtcUsd color={theme.usd} sats={totalBalance} size={'md'} hideBalance={isBalanceHidden} />
         )}
       </Column>
 
@@ -80,7 +122,7 @@ export function BalanceCard() {
           style={{
             width: '100%',
             padding: 12,
-            backgroundColor: '#F1CC9F',
+            backgroundColor: theme.expanded,
             borderRadius: 16,
             gap: 8,
             alignItems: 'flex-start'
@@ -88,21 +130,21 @@ export function BalanceCard() {
           <Column style={{ flex: 1, minWidth: 0, alignItems: 'flex-start' }} gap="xs">
             <Row itemsCenter gap="xs" style={{ height: 20 }}>
               <Text
-                color={'black_65'}
+                color={theme.detailLabel}
                 size="xs"
                 text={t('available')}
-                style={{ fontWeight: 500, lineHeight: '16px' }}
+                style={{ fontWeight: 500, lineHeight: '16px', opacity: isWatchOnly ? 0.7 : 1 }}
               />
               <div style={{ width: 16, height: 16, flexShrink: 0 }} />
             </Row>
-            <BtcDisplay preset="sub" balance={availableAmount} hideBalance={isBalanceHidden} />
+            <BtcDisplay preset="sub" balance={availableAmount} hideBalance={isBalanceHidden} variant={theme.variant} />
           </Column>
 
           <div
             style={{
               width: 1,
               alignSelf: 'stretch',
-              backgroundColor: 'rgba(109, 65, 0, 0.15)',
+              backgroundColor: theme.divider,
               flexShrink: 0
             }}
           />
@@ -110,10 +152,10 @@ export function BalanceCard() {
           <Column style={{ flex: 1, minWidth: 0, alignItems: 'flex-start' }} gap="xs">
             <Row itemsCenter gap="xs" style={{ height: 20 }}>
               <Text
-                color={'black_65'}
+                color={theme.detailLabel}
                 size="xs"
                 text={t('unavailable')}
-                style={{ fontWeight: 500, lineHeight: '16px' }}
+                style={{ fontWeight: 500, lineHeight: '16px', opacity: isWatchOnly ? 0.7 : 1 }}
               />
               <Tooltip
                 title={unavailableTipText}
@@ -125,10 +167,15 @@ export function BalanceCard() {
                 </div>
               </Tooltip>
             </Row>
-            <BtcDisplay preset="sub" balance={unavailableAmount} hideBalance={isBalanceHidden} />
+            <BtcDisplay
+              preset="sub"
+              balance={unavailableAmount}
+              hideBalance={isBalanceHidden}
+              variant={theme.variant}
+            />
           </Column>
 
-          {showUtxoToolButton ? (
+          {showUtxoToolButton && !isWatchOnly ? (
             <Tooltip
               title={`${t('unlock')} ->`}
               overlayStyle={{

--- a/apps/extension/src/ui/pages/Main/WalletTabScreen/components/BtcDisplay.tsx
+++ b/apps/extension/src/ui/pages/Main/WalletTabScreen/components/BtcDisplay.tsx
@@ -2,6 +2,7 @@ import { Column, Row, Text } from '@/ui/components';
 import { useBtcDisplayLogic, useBTCUnit, useChainType } from '@unisat/wallet-state';
 
 type Presets = keyof typeof $viewPresets;
+type Variant = 'gold' | 'grey';
 
 const $viewPresets = {
   main: {
@@ -24,18 +25,27 @@ const $viewPresets = {
   }
 };
 
+const $greyOverrides = {
+  mainPartColor: '#F5F5F7',
+  subPartColor: 'rgba(245, 245, 247, 0.55)',
+  unitPartColor: '#F5F5F7'
+};
+
 export function BtcDisplay({
   balance,
   hideBalance,
-  preset
+  preset,
+  variant = 'gold'
 }: {
   balance: string;
   hideBalance?: boolean;
   preset?: Presets;
+  variant?: Variant;
 }) {
   const chainType = useChainType();
   const btcUnit = useBTCUnit();
-  const $style = preset ? $viewPresets[preset] : $viewPresets['main'];
+  const base = preset ? $viewPresets[preset] : $viewPresets['main'];
+  const $style = variant === 'grey' ? { ...base, ...$greyOverrides } : base;
 
   const { totalAmountMainPart, totalAmountSubPart } = useBtcDisplayLogic(balance);
 

--- a/apps/extension/src/ui/pages/MainRoute.tsx
+++ b/apps/extension/src/ui/pages/MainRoute.tsx
@@ -64,7 +64,9 @@ import EditAccountNameScreen from './Settings/EditAccountNameScreen';
 import EditContactScreen from './Settings/EditContactScreen';
 import EditWalletNameScreen from './Settings/EditWalletNameScreen';
 import ExportMnemonicsScreen from './Settings/ExportMnemonicsScreen';
+import ExportDescriptorScreen from './Settings/ExportDescriptorScreen';
 import ExportPrivateKeyScreen from './Settings/ExportPrivateKeyScreen';
+import ImportDescriptorScreen from './Settings/ImportDescriptorScreen';
 import LanguageScreen from './Settings/LanguageScreen';
 import NetworkTypeScreen from './Settings/NetworkTypeScreen';
 import NotificationListScreen from './Settings/NotificationListScreen';
@@ -181,6 +183,14 @@ export const routes = {
   ExportPrivateKeyScreen: {
     path: '/settings/export-privatekey',
     element: <ExportPrivateKeyScreen />
+  },
+  ExportDescriptorScreen: {
+    path: '/settings/export-descriptor',
+    element: <ExportDescriptorScreen />
+  },
+  ImportDescriptorScreen: {
+    path: '/settings/import-descriptor',
+    element: <ImportDescriptorScreen />
   },
   AdvancedScreen: {
     path: '/settings/advanced',

--- a/apps/extension/src/ui/pages/Settings/AdvancedScreen/SecurityCard.tsx
+++ b/apps/extension/src/ui/pages/Settings/AdvancedScreen/SecurityCard.tsx
@@ -1,42 +1,33 @@
-import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Card, Column, Icon, Row, Text } from '@/ui/components';
 import { fontSizes } from '@/ui/theme/font';
+import { KeyringType } from '@unisat/keyring-service/types';
 import { getLockTimeInfo } from '@unisat/wallet-shared';
-import { useAutoLockTimeId, useChain, useCurrentKeyring, useI18n, useWallet } from '@unisat/wallet-state';
+import { useAutoLockTimeId, useChain, useCurrentKeyring, useI18n } from '@unisat/wallet-state';
 
+/**
+ * Descriptor export/import live here (not on the root Settings list).
+ * Path: Settings tab → Advanced → these rows.
+ */
 export function SecurityCard() {
   const navigate = useNavigate();
   const { t } = useI18n();
-  const wallet = useWallet();
   const autoLockTimeId = useAutoLockTimeId();
   const lockTimeConfig = getLockTimeInfo(autoLockTimeId, t);
   const currentKeyring = useCurrentKeyring();
   const chain = useChain();
-  const [canExport, setCanExport] = useState(false);
 
   // BIP-380 descriptors are Bitcoin-only (not Fractal)
   const descriptorsAvailable = !chain?.isFractal;
 
-  useEffect(() => {
-    let cancelled = false;
-    if (!descriptorsAvailable) {
-      setCanExport(false);
-      return;
-    }
-    wallet
-      .canExportAccountDescriptor()
-      .then((ok: boolean) => {
-        if (!cancelled) setCanExport(Boolean(ok));
-      })
-      .catch(() => {
-        if (!cancelled) setCanExport(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [wallet, descriptorsAvailable, currentKeyring?.key, currentKeyring?.type]);
+  // Show Export for HD / cold / watch — export screen shows a clear error if unsupported
+  // (avoids hiding the menu when canExport RPC is stale/unavailable).
+  const showExport =
+    descriptorsAvailable &&
+    (currentKeyring?.type === KeyringType.HdKeyring ||
+      currentKeyring?.type === KeyringType.ColdWalletKeyring ||
+      currentKeyring?.type === KeyringType.WatchAddressKeyring);
 
   return (
     <Card style={{ borderRadius: 10 }}>
@@ -67,7 +58,7 @@ export function SecurityCard() {
           </Row>
         </Row>
 
-        {canExport ? (
+        {showExport ? (
           <Row
             justifyBetween
             style={{

--- a/apps/extension/src/ui/pages/Settings/AdvancedScreen/SecurityCard.tsx
+++ b/apps/extension/src/ui/pages/Settings/AdvancedScreen/SecurityCard.tsx
@@ -1,20 +1,46 @@
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Card, Column, Icon, Row, Text } from '@/ui/components';
 import { fontSizes } from '@/ui/theme/font';
 import { getLockTimeInfo } from '@unisat/wallet-shared';
-import { useAutoLockTimeId, useI18n } from '@unisat/wallet-state';
+import { useAutoLockTimeId, useChain, useCurrentKeyring, useI18n, useWallet } from '@unisat/wallet-state';
 
 export function SecurityCard() {
   const navigate = useNavigate();
   const { t } = useI18n();
+  const wallet = useWallet();
   const autoLockTimeId = useAutoLockTimeId();
   const lockTimeConfig = getLockTimeInfo(autoLockTimeId, t);
+  const currentKeyring = useCurrentKeyring();
+  const chain = useChain();
+  const [canExport, setCanExport] = useState(false);
+
+  // BIP-380 descriptors are Bitcoin-only (not Fractal)
+  const descriptorsAvailable = !chain?.isFractal;
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!descriptorsAvailable) {
+      setCanExport(false);
+      return;
+    }
+    wallet
+      .canExportAccountDescriptor()
+      .then((ok: boolean) => {
+        if (!cancelled) setCanExport(Boolean(ok));
+      })
+      .catch(() => {
+        if (!cancelled) setCanExport(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [wallet, descriptorsAvailable, currentKeyring?.key, currentKeyring?.type]);
 
   return (
     <Card style={{ borderRadius: 10 }}>
       <Column fullX>
-        {/* Change Password Option */}
         <Row
           justifyBetween
           style={{
@@ -26,11 +52,11 @@ export function SecurityCard() {
           <Icon icon="right" size={fontSizes.lg} color="textDim" />
         </Row>
 
-        {/* Auto Lock Time Option */}
         <Row
           justifyBetween
           style={{
-            cursor: 'pointer'
+            cursor: 'pointer',
+            marginBottom: descriptorsAvailable ? 16 : 0
           }}
           onClick={() => navigate('/settings/lock-time')}>
           <Text text={t('automatic_lock_time')} size="sm" />
@@ -40,6 +66,31 @@ export function SecurityCard() {
             <Icon icon="right" size={fontSizes.lg} color="textDim" />
           </Row>
         </Row>
+
+        {canExport ? (
+          <Row
+            justifyBetween
+            style={{
+              cursor: 'pointer',
+              marginBottom: 16
+            }}
+            onClick={() => navigate('/settings/export-descriptor')}>
+            <Text text={t('export_descriptor_xpub')} size="sm" />
+            <Icon icon="right" size={fontSizes.lg} color="textDim" />
+          </Row>
+        ) : null}
+
+        {descriptorsAvailable ? (
+          <Row
+            justifyBetween
+            style={{
+              cursor: 'pointer'
+            }}
+            onClick={() => navigate('/settings/import-descriptor')}>
+            <Text text={t('import_descriptor')} size="sm" />
+            <Icon icon="right" size={fontSizes.lg} color="textDim" />
+          </Row>
+        ) : null}
       </Column>
     </Card>
   );

--- a/apps/extension/src/ui/pages/Settings/ExportDescriptorScreen.tsx
+++ b/apps/extension/src/ui/pages/Settings/ExportDescriptorScreen.tsx
@@ -1,0 +1,95 @@
+import { Button, Card, Column, Content, Header, Icon, Layout, Row, Text } from '@/ui/components';
+import { useExportDescriptorScreenLogic } from '@unisat/wallet-state';
+
+function CopyBlock({
+  label,
+  value,
+  onCopy
+}: {
+  label: string;
+  value: string;
+  onCopy: (str: string) => void;
+}) {
+  return (
+    <Column gap="sm">
+      <Text text={label} preset="sub" size="sm" />
+      <Card
+        onClick={() => {
+          onCopy(value);
+        }}>
+        <Row>
+          <Icon icon="copy" color="textDim" />
+          <Text text={value} color="textDim" size="xs" style={{ overflowWrap: 'anywhere' }} />
+        </Row>
+      </Card>
+    </Column>
+  );
+}
+
+export default function ExportDescriptorScreen() {
+  const {
+    t,
+    loading,
+    descriptor,
+    changeDescriptor,
+    xpub,
+    accountPath,
+    fingerprint,
+    policyLabel,
+    error,
+    copy,
+    onClickBack
+  } = useExportDescriptorScreenLogic();
+
+  return (
+    <Layout>
+      <Header onBack={onClickBack} title={t('export_descriptor_title')} />
+      <Content>
+        <Column gap="lg">
+          <Card>
+            <Column gap="md">
+              <Text text={t('export_descriptor_help')} preset="sub" size="sm" />
+              {policyLabel ? (
+                <Text
+                  text={(t('export_descriptor_policy') || 'Policy: $1').replace('$1', policyLabel)}
+                  preset="regular"
+                  size="sm"
+                  color="gold"
+                />
+              ) : null}
+              {accountPath || fingerprint ? (
+                <Text
+                  text={[fingerprint ? `Fingerprint: ${fingerprint}` : '', accountPath ? `Path: ${accountPath}` : '']
+                    .filter(Boolean)
+                    .join(' · ')}
+                  preset="sub"
+                  size="xs"
+                />
+              ) : null}
+            </Column>
+          </Card>
+
+          {loading && <Text text={t('loading') || 'Loading…'} preset="sub" textCenter />}
+          {error && <Text text={error} preset="regular" color="error" />}
+
+          {descriptor ? (
+            <Column gap="md">
+              <CopyBlock label={t('export_descriptor_receive')} value={descriptor} onCopy={copy} />
+
+              {changeDescriptor ? (
+                <CopyBlock label={t('export_descriptor_change')} value={changeDescriptor} onCopy={copy} />
+              ) : null}
+
+              {xpub ? <CopyBlock label={t('export_descriptor_account_xpub')} value={xpub} onCopy={copy} /> : null}
+
+              <Button text={t('export_descriptor_copy_receive')} preset="primary" onClick={() => copy(descriptor)} />
+              {xpub ? (
+                <Button text={t('export_descriptor_copy_xpub')} preset="default" onClick={() => copy(xpub)} />
+              ) : null}
+            </Column>
+          ) : null}
+        </Column>
+      </Content>
+    </Layout>
+  );
+}

--- a/apps/extension/src/ui/pages/Settings/ImportDescriptorScreen.tsx
+++ b/apps/extension/src/ui/pages/Settings/ImportDescriptorScreen.tsx
@@ -1,0 +1,117 @@
+import { Button, Card, Column, Content, Header, Input, Layout, Row, Text } from '@/ui/components';
+import { colors } from '@/ui/theme/colors';
+import { useImportDescriptorScreenLogic } from '@unisat/wallet-state';
+
+export default function ImportDescriptorScreen() {
+  const {
+    t,
+    raw,
+    setRaw,
+    name,
+    setName,
+    accountCount,
+    setAccountCount,
+    gapOptions,
+    error,
+    disabled,
+    busy,
+    preview,
+    onPreview,
+    onConfirmImport,
+    clearPreview,
+    onClickBack
+  } = useImportDescriptorScreenLogic();
+
+  return (
+    <Layout>
+      <Header onBack={onClickBack} title={t('import_descriptor_title')} />
+      <Content>
+        <Column gap="lg">
+          <Card>
+            <Column gap="sm">
+              <Text text={t('import_descriptor_help')} preset="sub" size="sm" />
+              <Text text={t('import_descriptor_watch_only_note')} preset="sub" size="sm" color="orange" />
+              <Text text={t('import_descriptor_gap_note')} preset="sub" size="sm" />
+              <Row gap="sm" style={{ flexWrap: 'wrap' }}>
+                {gapOptions.map((n) => (
+                  <Button
+                    key={n}
+                    preset={accountCount === n ? 'primary' : 'default'}
+                    text={
+                      n === 20
+                        ? t('import_descriptor_gap_20')
+                        : n === 50
+                          ? t('import_descriptor_gap_50')
+                          : t('import_descriptor_gap_100')
+                    }
+                    onClick={() => setAccountCount(n)}
+                    style={{
+                      minHeight: 32,
+                      borderColor: accountCount === n ? undefined : colors.border2
+                    }}
+                  />
+                ))}
+              </Row>
+            </Column>
+          </Card>
+
+          <Input
+            preset="text"
+            placeholder={t('import_descriptor_wallet_name')}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+
+          <Input
+            preset="text"
+            placeholder={t('import_descriptor_placeholder')}
+            value={raw}
+            onChange={(e) => setRaw(e.target.value)}
+            style={{ minHeight: 120 }}
+          />
+
+          {preview ? (
+            <Card>
+              <Column gap="sm">
+                <Text text={t('import_descriptor_confirm_title')} preset="bold" size="sm" />
+                <Text text={t('import_descriptor_confirm_note')} preset="sub" size="sm" color="orange" />
+                {preview.policyLabel ? (
+                  <Text text={preview.policyLabel} size="xs" color="gold" />
+                ) : null}
+                {preview.previewAddresses.map((addr, i) => (
+                  <Text key={addr} text={`#${i}  ${addr}`} size="xs" style={{ wordBreak: 'break-all' }} />
+                ))}
+              </Column>
+            </Card>
+          ) : null}
+
+          {error && <Text text={error} preset="regular" color="error" />}
+
+          {!preview ? (
+            <Button
+              text={busy ? t('loading') || 'Checking…' : t('import_descriptor_preview')}
+              preset="primary"
+              disabled={disabled}
+              onClick={onPreview}
+            />
+          ) : (
+            <Column gap="sm">
+              <Button
+                text={busy ? t('loading') || 'Importing…' : t('import_descriptor_confirm_button')}
+                preset="primary"
+                disabled={busy}
+                onClick={onConfirmImport}
+              />
+              <Button
+                text={t('cancel') || 'Cancel'}
+                preset="default"
+                disabled={busy}
+                onClick={clearPreview}
+              />
+            </Column>
+          )}
+        </Column>
+      </Content>
+    </Layout>
+  );
+}

--- a/apps/extension/src/ui/pages/Settings/ImportDescriptorScreen.tsx
+++ b/apps/extension/src/ui/pages/Settings/ImportDescriptorScreen.tsx
@@ -67,6 +67,9 @@ export default function ImportDescriptorScreen() {
             placeholder={t('import_descriptor_placeholder')}
             value={raw}
             onChange={(e) => setRaw(e.target.value)}
+            rows={6}
+            spellCheck={false}
+            autoComplete="off"
             style={{ minHeight: 120 }}
           />
 

--- a/packages/descriptor-service/README.md
+++ b/packages/descriptor-service/README.md
@@ -1,0 +1,13 @@
+# @unisat/descriptor-service
+
+BIP-380 singlesig output descriptors for UniSat Wallet.
+
+## v1
+
+- BIP-380 checksum (BigInt polymod) + parse / script-type policy label
+- `hdAccountToDescriptor` / `hdAccountToDescriptorPair` for `P2WPKH` / `P2TR` / `P2SH_P2WPKH` / `P2PKH`
+- `deriveAddresses` for ranged singlesig `wpkh` / `tr` / `sh(wpkh)` / `pkh`
+- `normalizeMultipathImport` for Sparrow-style `/<0;1>/*` → receive `/0/*` + change `/1/*`
+- Rejects private `xprv`, SLIP-132, hardened-after-xpub, and non-Sparrow multipath
+
+Multisig / Miniscript script trees are out of scope for v1.

--- a/packages/descriptor-service/package.json
+++ b/packages/descriptor-service/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@unisat/descriptor-service",
+  "version": "0.1.0",
+  "description": "BIP-380 singlesig output descriptors for UniSat Wallet",
+  "private": true,
+  "main": "lib/index.js",
+  "module": "lib/index.mjs",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib/**/*",
+    "src/**/*",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "require": "./lib/index.js",
+      "import": "./lib/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src --ext .ts",
+    "clean": "rm -rf lib",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "bitcoin",
+    "descriptor",
+    "bip380",
+    "unisat"
+  ],
+  "author": "UniSat",
+  "license": "MIT",
+  "dependencies": {
+    "@bitcoinerlab/secp256k1": "^1.0.5",
+    "bip32": "^4.0.0",
+    "bitcoinjs-lib": "^6.1.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20.8.0",
+    "tsup": "^7.2.0",
+    "typescript": "^5.2.0",
+    "vitest": "^0.34.0"
+  }
+}

--- a/packages/descriptor-service/src/account.ts
+++ b/packages/descriptor-service/src/account.ts
@@ -1,0 +1,152 @@
+import { descriptorChecksum } from './checksum'
+import { descriptorBodyWithoutOrigin, extractSinglesigKey } from './derive'
+import { parseDescriptor } from './parse'
+import { normalizeFingerprint, toDescriptorPath } from './path'
+import {
+  DescriptorAddressType,
+  DescriptorError,
+  HdAccountDescriptorInput
+} from './types'
+
+const ORIGIN_DESC_PATH = /^[0-9]+h?(?:\/[0-9]+h?)*$/
+const XPUB_AFTER =
+  '(xpub[1-9A-HJ-NP-Za-km-z]{79,108}|tpub[1-9A-HJ-NP-Za-km-z]{79,108})'
+/** Sparrow / BIP-389 receive+change multipath after the xpub only. */
+const MULTIPATH_01 = new RegExp(`${XPUB_AFTER}/<0;1>/\\*`, 'i')
+
+function wrapperFor(addressType: DescriptorAddressType, keyExpr: string): string {
+  switch (addressType) {
+    case DescriptorAddressType.P2WPKH:
+      return `wpkh(${keyExpr})`
+    case DescriptorAddressType.P2TR:
+      return `tr(${keyExpr})`
+    case DescriptorAddressType.P2SH_P2WPKH:
+      return `sh(wpkh(${keyExpr}))`
+    case DescriptorAddressType.P2PKH:
+      return `pkh(${keyExpr})`
+    default:
+      throw new DescriptorError(
+        `Unsupported address type for descriptor export: ${addressType}`,
+        'UNSUPPORTED'
+      )
+  }
+}
+
+export type XpubLevel = 'account' | 'chain'
+
+/**
+ * Build a checksummed watch-only descriptor for a UniSat HD account xpub.
+ * - account level (default): xpub at m/86'/0'/0' → `…xpub/0/*`
+ * - chain level: xpub at m/86'/0'/0'/0 → `…xpub/*`
+ */
+export function hdAccountToDescriptor(
+  input: HdAccountDescriptorInput & { xpubLevel?: XpubLevel }
+): string {
+  if (!input.xpub?.startsWith('xpub') && !input.xpub?.startsWith('tpub')) {
+    throw new DescriptorError('Account xpub required (xpub/tpub)', 'UNSUPPORTED')
+  }
+  const level = input.xpubLevel ?? 'account'
+  let suffix: string
+  if (level === 'chain') {
+    suffix = '/*'
+  } else {
+    const chain = input.chain ?? 0
+    if (chain !== 0 && chain !== 1) {
+      throw new DescriptorError('chain must be 0 (receive) or 1 (change)', 'UNSUPPORTED')
+    }
+    suffix = `/${chain}/*`
+  }
+
+  // Omit origin when fingerprint is missing/placeholder — never invent 00000000
+  let keyExpr = `${input.xpub}${suffix}`
+  const rawFpr = input.origin?.fingerprint?.trim()
+  const path = input.origin?.path?.trim()
+  if (rawFpr && path && !/^0+$/.test(rawFpr.replace(/^0x/i, ''))) {
+    const fpr = normalizeFingerprint(rawFpr)
+    const descPath = toDescriptorPath(path)
+    if (!ORIGIN_DESC_PATH.test(descPath)) {
+      throw new DescriptorError(`Invalid origin path: ${path}`, 'PARSE')
+    }
+    keyExpr = `[${fpr}/${descPath}]${input.xpub}${suffix}`
+  }
+
+  const body = wrapperFor(input.addressType, keyExpr)
+  return `${body}#${descriptorChecksum(body)}`
+}
+
+/** Convenience: both receive and change descriptors. */
+export function hdAccountToDescriptorPair(input: Omit<HdAccountDescriptorInput, 'chain'>): {
+  receive: string
+  change: string
+} {
+  return {
+    receive: hdAccountToDescriptor({ ...input, chain: 0 }),
+    change: hdAccountToDescriptor({ ...input, chain: 1 })
+  }
+}
+
+/**
+ * Expand Sparrow-style checksummed multipath `…xpub/<0;1>/*` into receive `/0/*` + change `/1/*`.
+ * Returns null when the descriptor is not multipath (caller keeps the original).
+ * Rejects other multipath forms (wrong order, extra branches, nested).
+ */
+export function normalizeMultipathImport(
+  rawDescriptor: string
+): { receive: string; change: string } | null {
+  const parsed = parseDescriptor(rawDescriptor.trim())
+  const keyBody = descriptorBodyWithoutOrigin(parsed.body)
+  if (!keyBody.includes('<') && !keyBody.includes(';')) {
+    return null
+  }
+  MULTIPATH_01.lastIndex = 0
+  if (!MULTIPATH_01.test(parsed.body)) {
+    throw new DescriptorError(
+      'Only Sparrow-style multipath /<0;1>/* is supported; paste receive ending in /0/* or a single /<0;1>/* descriptor',
+      'UNSUPPORTED'
+    )
+  }
+  MULTIPATH_01.lastIndex = 0
+  const receiveBody = parsed.body.replace(MULTIPATH_01, '$1/0/*')
+  MULTIPATH_01.lastIndex = 0
+  const changeBody = parsed.body.replace(MULTIPATH_01, '$1/1/*')
+  if (
+    receiveBody === parsed.body ||
+    changeBody === parsed.body ||
+    receiveBody.includes('<') ||
+    receiveBody.includes(';') ||
+    changeBody.includes('<') ||
+    changeBody.includes(';')
+  ) {
+    throw new DescriptorError(
+      'Only Sparrow-style multipath /<0;1>/* is supported; paste receive ending in /0/* or a single /<0;1>/* descriptor',
+      'UNSUPPORTED'
+    )
+  }
+  return {
+    receive: `${receiveBody}#${descriptorChecksum(receiveBody)}`,
+    change: `${changeBody}#${descriptorChecksum(changeBody)}`,
+  }
+}
+
+/**
+ * From a checksummed receive descriptor ending in `/0/*`, build the sibling `/1/*` change descriptor.
+ * Returns undefined if the input is not a standard receive wildcard shape.
+ * Only rewrites the key-expression `/0/*` after the xpub — never an origin path.
+ */
+export function siblingChangeDescriptor(receiveDescriptor: string): string | undefined {
+  const parsed = parseDescriptor(receiveDescriptor)
+  if (!descriptorBodyWithoutOrigin(parsed.body).includes('/0/*')) return undefined
+  let keyInfo
+  try {
+    keyInfo = extractSinglesigKey(parsed.body)
+  } catch {
+    return undefined
+  }
+  if (keyInfo.chainPath !== '0') return undefined
+  const changeBody = parsed.body.replace(
+    new RegExp(`${XPUB_AFTER}/0/\\*`, 'i'),
+    '$1/1/*'
+  )
+  if (changeBody === parsed.body) return undefined
+  return `${changeBody}#${descriptorChecksum(changeBody)}`
+}

--- a/packages/descriptor-service/src/bitcoin.ts
+++ b/packages/descriptor-service/src/bitcoin.ts
@@ -1,0 +1,16 @@
+import * as ecc from '@bitcoinerlab/secp256k1'
+import { BIP32Factory, BIP32Interface } from 'bip32'
+import * as bitcoin from 'bitcoinjs-lib'
+
+bitcoin.initEccLib(ecc)
+
+export const bip32 = BIP32Factory(ecc)
+export { bitcoin, BIP32Interface }
+
+export function networkFromName(
+  name: 'mainnet' | 'testnet' | 'signet' | 'regtest' = 'mainnet'
+): bitcoin.Network {
+  if (name === 'regtest') return bitcoin.networks.regtest
+  if (name === 'testnet' || name === 'signet') return bitcoin.networks.testnet
+  return bitcoin.networks.bitcoin
+}

--- a/packages/descriptor-service/src/checksum.ts
+++ b/packages/descriptor-service/src/checksum.ts
@@ -1,0 +1,78 @@
+/**
+ * BIP-380 descriptor checksum (reference algorithm from the BIP).
+ * Uses BigInt because JS bitwise operators are 32-bit; polymod needs ~40 bits.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki
+ */
+
+const INPUT_CHARSET =
+  "0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ "
+const CHECKSUM_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
+const GENERATOR = [
+  0xf5dee51989n,
+  0xa9fdca3312n,
+  0x1bab10e32dn,
+  0x3706b1677an,
+  0x644d626ffdn
+]
+const MASK_35 = 0x7ffffffffn
+
+function polyMod(symbols: number[]): bigint {
+  let chk = 1n
+  for (const value of symbols) {
+    const top = chk >> 35n
+    chk = ((chk & MASK_35) << 5n) ^ BigInt(value)
+    for (let i = 0; i < 5; i++) {
+      if ((top >> BigInt(i)) & 1n) chk ^= GENERATOR[i]
+    }
+  }
+  return chk
+}
+
+function expand(s: string): number[] | null {
+  const groups: number[] = []
+  const symbols: number[] = []
+  for (const c of s) {
+    const v = INPUT_CHARSET.indexOf(c)
+    if (v === -1) return null
+    symbols.push(v & 31)
+    groups.push(v >> 5)
+    if (groups.length === 3) {
+      symbols.push(groups[0] * 9 + groups[1] * 3 + groups[2])
+      groups.length = 0
+    }
+  }
+  if (groups.length === 1) {
+    symbols.push(groups[0])
+  } else if (groups.length === 2) {
+    symbols.push(groups[0] * 3 + groups[1])
+  }
+  return symbols
+}
+
+/** Return 8-character checksum for descriptor body (no '#'). */
+export function descriptorChecksum(body: string): string {
+  const expanded = expand(body)
+  if (!expanded) {
+    throw new Error('Invalid descriptor character set')
+  }
+  const symbols = expanded.concat([0, 0, 0, 0, 0, 0, 0, 0])
+  const checksum = polyMod(symbols) ^ 1n
+  let out = ''
+  for (let i = 0; i < 8; i++) {
+    out += CHECKSUM_CHARSET[Number((checksum >> BigInt(5 * (7 - i))) & 31n)]
+  }
+  return out
+}
+
+export function verifyDescriptorChecksum(raw: string): boolean {
+  if (raw.length < 10 || raw[raw.length - 9] !== '#') return false
+  const checksum = raw.slice(-8)
+  if (![...checksum].every((c) => CHECKSUM_CHARSET.includes(c))) return false
+  const body = raw.slice(0, -9)
+  const expanded = expand(body)
+  if (!expanded) return false
+  const symbols = expanded.concat(
+    [...checksum].map((c) => CHECKSUM_CHARSET.indexOf(c))
+  )
+  return polyMod(symbols) === 1n
+}

--- a/packages/descriptor-service/src/derive.ts
+++ b/packages/descriptor-service/src/derive.ts
@@ -1,0 +1,263 @@
+import { bip32, bitcoin, networkFromName } from './bitcoin'
+import { parseDescriptor } from './parse'
+import { toBip32Path } from './path'
+import {
+  DeriveAddressOptions,
+  DescriptorError,
+  DescriptorScriptKind
+} from './types'
+
+interface SinglesigKeyInfo {
+  kind: DescriptorScriptKind
+  xpub: string
+  /** Relative path after xpub before wildcard, e.g. `0` for `/0/*` */
+  chainPath: string
+}
+
+/**
+ * Extract singlesig xpub + chain from a limited set of descriptor shapes:
+ * wpkh(...), tr(...), sh(wpkh(...)), pkh(...)
+ *
+ * Origin path: digits + h/' only — never `*` or hex letters (avoids /* phishing in [fpr/…]).
+ */
+const ORIGIN_PATH = '([0-9]+[hH\']?(?:\\/[0-9]+[hH\']?)*)'
+const XPUB =
+  '(xpub[1-9A-HJ-NP-Za-km-z]{79,108}|tpub[1-9A-HJ-NP-Za-km-z]{79,108})'
+/** Key expression after xpub: must end with `*` for v1 ranged import/derive. */
+const AFTER_XPUB = '([0-9hH/\'*]+)'
+
+/** Non-hardened BIP32 child index must be < 2^31. */
+const MAX_NON_HARDENED_INDEX = 0x80000000
+
+/** Body with `[fpr/path]` stripped — use for /* /0/* /1/* presence checks. */
+export function descriptorBodyWithoutOrigin(body: string): string {
+  return body.replace(/\[[0-9a-fA-F]{8}\/[0-9]+[hH']?(?:\/[0-9]+[hH']?)*\]/g, '')
+}
+
+export function extractSinglesigKey(body: string): SinglesigKeyInfo {
+  // Reject private extended keys at key boundaries (not substring of a valid xpub)
+  if (/(?:^|[[(,/\s])([xtyuz]prv)/i.test(body)) {
+    throw new DescriptorError(
+      'Private descriptors (xprv) are not supported; use a watch-only xpub descriptor',
+      'UNSUPPORTED'
+    )
+  }
+  // Raw multipath is not a single chainPath — expand /<0;1>/* via normalizeMultipathImport first
+  if (body.includes('<') || body.includes(';')) {
+    throw new DescriptorError(
+      'Multipath descriptors must be normalized first (use normalizeMultipathImport for /<0;1>/*, else paste /0/*)',
+      'UNSUPPORTED'
+    )
+  }
+  // SLIP-132 versions — common from Electrum/Ledger; fail with a targeted hint
+  if (/(?:^|[[(,/\s])([yzuv]pub)/i.test(body)) {
+    throw new DescriptorError(
+      'SLIP-132 keys (ypub/zpub/upub/vpub) are not supported; convert to BIP-32 xpub/tpub',
+      'UNSUPPORTED'
+    )
+  }
+  // v1: key-path Taproot only (no script tree)
+  if (body.startsWith('tr(') && body.includes(',{')) {
+    throw new DescriptorError(
+      'Taproot script-path descriptors are not supported in v1',
+      'UNSUPPORTED'
+    )
+  }
+
+  const patterns: { kind: DescriptorScriptKind; re: RegExp }[] = [
+    {
+      kind: 'sh-wpkh',
+      re: new RegExp(
+        `^sh\\(wpkh\\((?:\\[([0-9a-fA-F]{8})\\/${ORIGIN_PATH}\\])?${XPUB}(?:\\/${AFTER_XPUB})?\\)\\)$`
+      )
+    },
+    {
+      kind: 'wpkh',
+      re: new RegExp(
+        `^wpkh\\((?:\\[([0-9a-fA-F]{8})\\/${ORIGIN_PATH}\\])?${XPUB}(?:\\/${AFTER_XPUB})?\\)$`
+      )
+    },
+    {
+      kind: 'tr',
+      re: new RegExp(
+        `^tr\\((?:\\[([0-9a-fA-F]{8})\\/${ORIGIN_PATH}\\])?${XPUB}(?:\\/${AFTER_XPUB})?(?:,\\{[^)]+\\})?\\)$`
+      )
+    },
+    {
+      kind: 'pkh',
+      re: new RegExp(
+        `^pkh\\((?:\\[([0-9a-fA-F]{8})\\/${ORIGIN_PATH}\\])?${XPUB}(?:\\/${AFTER_XPUB})?\\)$`
+      )
+    }
+  ]
+
+  for (const { kind, re } of patterns) {
+    const m = body.match(re)
+    if (!m) continue
+    const xpub = m[3]
+    const rawAfter = m[4] || ''
+    if (!xpub) {
+      throw new DescriptorError('Could not parse xpub from descriptor', 'PARSE')
+    }
+    // Fail closed: fixed paths (…/0/0) must not be treated as a gap
+    if (!rawAfter.endsWith('*')) {
+      throw new DescriptorError(
+        'Ranged descriptor required (must end with /*), e.g. wpkh(xpub…/0/*)#checksum',
+        'UNSUPPORTED'
+      )
+    }
+    const after = rawAfter.replace(/\/?\*$/, '').replace(/^\//, '')
+    // Public nodes cannot harden; fail closed before bip32 throws
+    if (/[hH']/.test(after)) {
+      throw new DescriptorError('Hardened derivation after xpub is not supported', 'UNSUPPORTED')
+    }
+    // v1: only /* (chain-level), /0/* (receive), /1/* (change)
+    if (after !== '' && after !== '0' && after !== '1') {
+      throw new DescriptorError(
+        'Only /*, /0/*, or /1/* wildcards are supported in v1',
+        'UNSUPPORTED'
+      )
+    }
+    return { kind, xpub, chainPath: after }
+  }
+
+  throw new DescriptorError(
+    'Only singlesig wpkh/tr/sh(wpkh)/pkh descriptors are supported in v1',
+    'UNSUPPORTED'
+  )
+}
+
+function pubkeyToAddress(
+  kind: DescriptorScriptKind,
+  pubkey: Buffer,
+  network: bitcoin.Network
+): string {
+  if (kind === 'wpkh') {
+    const { address } = bitcoin.payments.p2wpkh({ pubkey, network })
+    if (!address) throw new DescriptorError('Failed to derive wpkh address', 'DERIVE')
+    return address
+  }
+  if (kind === 'sh-wpkh') {
+    const redeem = bitcoin.payments.p2wpkh({ pubkey, network })
+    const { address } = bitcoin.payments.p2sh({ redeem, network })
+    if (!address) throw new DescriptorError('Failed to derive sh-wpkh address', 'DERIVE')
+    return address
+  }
+  if (kind === 'pkh') {
+    const { address } = bitcoin.payments.p2pkh({ pubkey, network })
+    if (!address) throw new DescriptorError('Failed to derive pkh address', 'DERIVE')
+    return address
+  }
+  if (kind === 'tr') {
+    const { address } = bitcoin.payments.p2tr({
+      internalPubkey: pubkey.subarray(1, 33),
+      network
+    })
+    if (!address) throw new DescriptorError('Failed to derive tr address', 'DERIVE')
+    return address
+  }
+  throw new DescriptorError(`Cannot derive addresses for kind ${kind}`, 'UNSUPPORTED')
+}
+
+function deriveChildPubkey(
+  xpub: string,
+  chainPath: string,
+  index: number,
+  network: bitcoin.Network
+): Buffer {
+  if (!Number.isInteger(index) || index < 0 || index >= MAX_NON_HARDENED_INDEX) {
+    throw new DescriptorError(
+      `Derivation index out of range (0..${MAX_NON_HARDENED_INDEX - 1})`,
+      'DERIVE'
+    )
+  }
+  let node
+  try {
+    node = bip32.fromBase58(xpub, network)
+  } catch {
+    throw new DescriptorError(
+      'Invalid xpub for the selected network (mainnet xpub vs testnet tpub mismatch?)',
+      'DERIVE'
+    )
+  }
+  if (chainPath) {
+    // chainPath may be `0` or `0/1` style without wildcard
+    const rel = chainPath
+      .split('/')
+      .filter(Boolean)
+      .map((p) => p.replace(/h$/i, "'"))
+      .join('/')
+    if (rel.includes('*')) {
+      throw new DescriptorError('Unexpected wildcard in chain path', 'PARSE')
+    }
+    if (rel) {
+      try {
+        node = node.derivePath(rel) as typeof node
+      } catch {
+        throw new DescriptorError('Failed to derive chain path from xpub', 'DERIVE')
+      }
+    }
+  }
+  const child = node.derive(index)
+  return Buffer.from(child.publicKey)
+}
+
+/**
+ * Derive receive/change addresses from a checksummed singlesig descriptor.
+ */
+export function deriveAddresses(
+  rawDescriptor: string,
+  options: DeriveAddressOptions = {}
+): string[] {
+  const parsed = parseDescriptor(rawDescriptor)
+  // Ignore /* inside origin [fpr/…] — only the key expression after xpub counts
+  if (!descriptorBodyWithoutOrigin(parsed.body).includes('/*')) {
+    throw new DescriptorError(
+      'Ranged descriptor required (must include /*), e.g. wpkh(xpub…/0/*)#checksum',
+      'UNSUPPORTED'
+    )
+  }
+  const { kind, xpub, chainPath } = extractSinglesigKey(parsed.body)
+  const network = networkFromName(options.network ?? 'mainnet')
+  const start = options.start ?? 0
+  const count = options.count ?? 1
+  if (!Number.isInteger(start) || start < 0) {
+    throw new DescriptorError('start must be a non-negative integer', 'DERIVE')
+  }
+  if (!Number.isInteger(count) || count < 1 || count > 1000) {
+    throw new DescriptorError('count must be between 1 and 1000', 'DERIVE')
+  }
+  if (start + count > MAX_NON_HARDENED_INDEX) {
+    throw new DescriptorError(
+      `start+count exceeds max non-hardened index (${MAX_NON_HARDENED_INDEX - 1})`,
+      'DERIVE'
+    )
+  }
+
+  const out: string[] = []
+  for (let i = 0; i < count; i++) {
+    const pubkey = deriveChildPubkey(xpub, chainPath, start + i, network)
+    out.push(pubkeyToAddress(kind, pubkey, network))
+  }
+  return out
+}
+
+export function addressTypeHintFromKind(
+  kind: DescriptorScriptKind
+): 'P2WPKH' | 'P2TR' | 'P2SH_P2WPKH' | 'P2PKH' | 'UNKNOWN' {
+  switch (kind) {
+    case 'wpkh':
+      return 'P2WPKH'
+    case 'tr':
+      return 'P2TR'
+    case 'sh-wpkh':
+      return 'P2SH_P2WPKH'
+    case 'pkh':
+      return 'P2PKH'
+    default:
+      return 'UNKNOWN'
+  }
+}
+
+/** Re-export for callers that need path conversion when building from HD. */
+export { toBip32Path }

--- a/packages/descriptor-service/src/index.ts
+++ b/packages/descriptor-service/src/index.ts
@@ -1,0 +1,26 @@
+export { descriptorChecksum, verifyDescriptorChecksum } from './checksum'
+export { parseDescriptor } from './parse'
+export {
+  hdAccountToDescriptor,
+  hdAccountToDescriptorPair,
+  normalizeMultipathImport,
+  siblingChangeDescriptor
+} from './account'
+export type { XpubLevel } from './account'
+export {
+  deriveAddresses,
+  extractSinglesigKey,
+  addressTypeHintFromKind,
+  descriptorBodyWithoutOrigin
+} from './derive'
+export { toDescriptorPath, toBip32Path, normalizeFingerprint } from './path'
+export type {
+  DescriptorNetwork,
+  DescriptorScriptKind,
+  ParsedDescriptor,
+  PolicySummary,
+  KeyOrigin,
+  HdAccountDescriptorInput,
+  DeriveAddressOptions
+} from './types'
+export { DescriptorError, DescriptorAddressType } from './types'

--- a/packages/descriptor-service/src/parse.ts
+++ b/packages/descriptor-service/src/parse.ts
@@ -1,0 +1,75 @@
+import { verifyDescriptorChecksum } from './checksum'
+import {
+  DescriptorError,
+  DescriptorScriptKind,
+  ParsedDescriptor,
+  PolicySummary
+} from './types'
+
+function detectKind(body: string): DescriptorScriptKind {
+  const b = body.trim()
+  if (b.startsWith('tr(')) return 'tr'
+  if (b.startsWith('wpkh(')) return 'wpkh'
+  if (b.startsWith('wsh(')) return 'wsh'
+  if (b.startsWith('sh(wpkh(')) return 'sh-wpkh'
+  if (b.startsWith('sh(')) return 'sh'
+  if (b.startsWith('pkh(')) return 'pkh'
+  return 'unknown'
+}
+
+function policyFor(kind: DescriptorScriptKind, body: string): PolicySummary {
+  const complex =
+    kind === 'wsh' ||
+    body.includes('multi(') ||
+    body.includes('multi_a(') ||
+    body.includes('sortedmulti') ||
+    body.includes('thresh(') ||
+    body.includes('older(') ||
+    body.includes('after(')
+
+  // Plain-language script type (avoid Miniscript “policy” jargon for singlesig)
+  const labels: Record<DescriptorScriptKind, string> = {
+    tr: complex ? 'Script: Taproot (script paths)' : 'Script: Taproot (single key)',
+    wpkh: 'Script: Native SegWit (single key)',
+    'sh-wpkh': 'Script: Nested SegWit (single key)',
+    wsh: 'Script: SegWit (multisig / miniscript)',
+    sh: 'Script: Legacy P2SH',
+    pkh: 'Script: Legacy P2PKH',
+    unknown: 'Script: Unknown'
+  }
+
+  return {
+    label: labels[kind],
+    kind,
+    isComplex: complex
+  }
+}
+
+/**
+ * Validate BIP-380 checksum and return a lightweight parse (kind + policy label).
+ * Address derivation is `deriveAddresses` / `extractSinglesigKey`.
+ */
+export function parseDescriptor(raw: string): ParsedDescriptor {
+  const trimmed = raw.trim()
+  if (!trimmed) {
+    throw new DescriptorError('Descriptor is empty', 'EMPTY')
+  }
+  // Checksum is exactly 8 chars after a final '#'; reject other '#' placements.
+  if (trimmed.length < 10 || trimmed[trimmed.length - 9] !== '#') {
+    throw new DescriptorError('Descriptor missing #checksum', 'MISSING_CHECKSUM')
+  }
+  if (!verifyDescriptorChecksum(trimmed)) {
+    throw new DescriptorError('Descriptor checksum invalid', 'INVALID_CHECKSUM')
+  }
+  const hash = trimmed.length - 9
+  const body = trimmed.slice(0, hash)
+  const checksum = trimmed.slice(hash + 1)
+  const kind = detectKind(body)
+  return {
+    raw: trimmed,
+    body,
+    checksum,
+    kind,
+    policy: policyFor(kind, body)
+  }
+}

--- a/packages/descriptor-service/src/path.ts
+++ b/packages/descriptor-service/src/path.ts
@@ -1,0 +1,21 @@
+/** Normalize BIP-32 path to descriptor form: `86h/0h/0h` (no leading m/). */
+export function toDescriptorPath(path: string): string {
+  let p = path.trim()
+  if (p.startsWith('m/')) p = p.slice(2)
+  else if (p.startsWith('m')) p = p.slice(1).replace(/^\//, '')
+  return p.replace(/'/g, 'h')
+}
+
+/** Convert descriptor path `86h/0h/0h` to bip32 `m/86'/0'/0'`. */
+export function toBip32Path(path: string): string {
+  const body = toDescriptorPath(path).replace(/h/g, "'")
+  return body.startsWith('m/') ? body : `m/${body}`
+}
+
+export function normalizeFingerprint(fingerprint: string): string {
+  const hex = fingerprint.trim().toLowerCase().replace(/^0x/, '')
+  if (!/^[0-9a-f]{8}$/.test(hex)) {
+    throw new Error(`Invalid master fingerprint: ${fingerprint}`)
+  }
+  return hex
+}

--- a/packages/descriptor-service/src/types.ts
+++ b/packages/descriptor-service/src/types.ts
@@ -1,0 +1,85 @@
+export type DescriptorNetwork = 'mainnet' | 'testnet' | 'signet' | 'regtest'
+
+/** High-level script family for UI policy chips */
+export type DescriptorScriptKind =
+  | 'wpkh'
+  | 'sh-wpkh'
+  | 'tr'
+  | 'wsh'
+  | 'sh'
+  | 'pkh'
+  | 'unknown'
+
+/**
+ * UniSat AddressType subset supported for descriptor export/derive (v1).
+ * Numeric values match `@unisat/wallet-types` AddressType.
+ */
+export enum DescriptorAddressType {
+  P2PKH = 0,
+  P2WPKH = 1,
+  P2TR = 2,
+  P2SH_P2WPKH = 3
+}
+
+export interface PolicySummary {
+  /** Short label for UI, e.g. "Taproot single key" */
+  label: string
+  kind: DescriptorScriptKind
+  /** True if more than one key or a miniscript threshold/timelock is present */
+  isComplex: boolean
+}
+
+export interface ParsedDescriptor {
+  /** Full input including checksum */
+  raw: string
+  /** Descriptor without #checksum */
+  body: string
+  checksum: string
+  kind: DescriptorScriptKind
+  policy: PolicySummary
+}
+
+export interface KeyOrigin {
+  /** 8 hex chars (4-byte master fingerprint), no 0x */
+  fingerprint: string
+  /**
+   * Hardened account path using `h` or `'`, with or without leading `m/`.
+   * Example: `86h/0h/0h` or `m/86'/0'/0'`
+   */
+  path: string
+}
+
+export interface HdAccountDescriptorInput {
+  addressType: DescriptorAddressType
+  /**
+   * Key origin. Omit or leave fingerprint empty/zero to export without `[fpr/path]`
+   * (preferred over inventing `00000000`).
+   */
+  origin?: KeyOrigin
+  /** Account-level xpub (e.g. at m/86'/0'/0') */
+  xpub: string
+  /** Receive (0) or change (1). Default receive. */
+  chain?: 0 | 1
+}
+
+export interface DeriveAddressOptions {
+  network?: DescriptorNetwork
+  start?: number
+  count?: number
+}
+
+export class DescriptorError extends Error {
+  constructor(
+    message: string,
+    readonly code:
+      | 'EMPTY'
+      | 'MISSING_CHECKSUM'
+      | 'INVALID_CHECKSUM'
+      | 'UNSUPPORTED'
+      | 'PARSE'
+      | 'DERIVE'
+  ) {
+    super(message)
+    this.name = 'DescriptorError'
+  }
+}

--- a/packages/descriptor-service/test/account-origin.test.ts
+++ b/packages/descriptor-service/test/account-origin.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { hdAccountToDescriptor, parseDescriptor, verifyDescriptorChecksum } from '../src'
+import { DescriptorAddressType } from '../src/types'
+
+const WPKH_XPUB =
+  'xpub6CatWdiZiodmUeTDp8LT5or8nmbKNcuyvz7WyksVFkKB4RHwCD3XyuvPEbvqAQY3rAPshWcMLoP2fMFMKHPJ4ZeZXYVUhLv1VMrjPC7PW6V'
+
+describe('hdAccountToDescriptor origin handling', () => {
+  it('includes origin when fingerprint is real', () => {
+    const d = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: '73c5da0a', path: "m/84'/0'/0'" },
+      xpub: WPKH_XPUB,
+      chain: 0
+    })
+    expect(d.startsWith('wpkh([73c5da0a/84h/0h/0h]')).toBe(true)
+    expect(verifyDescriptorChecksum(d)).toBe(true)
+  })
+
+  it('omits origin when fingerprint is missing (never invents 00000000)', () => {
+    const d = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      xpub: WPKH_XPUB,
+      xpubLevel: 'chain'
+    })
+    expect(d.includes('[')).toBe(false)
+    expect(d.includes('00000000')).toBe(false)
+    expect(d.startsWith('wpkh(')).toBe(true)
+    expect(verifyDescriptorChecksum(d)).toBe(true)
+    expect(parseDescriptor(d).policy.kind).toBe('wpkh')
+  })
+
+  it('omits origin when fingerprint is all zeros', () => {
+    const d = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: '00000000', path: "m/84'/0'/0'/0" },
+      xpub: WPKH_XPUB,
+      xpubLevel: 'chain'
+    })
+    expect(d.includes('00000000')).toBe(false)
+    expect(d.includes('[')).toBe(false)
+  })
+})

--- a/packages/descriptor-service/test/bip-vectors.test.ts
+++ b/packages/descriptor-service/test/bip-vectors.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DescriptorAddressType,
+  deriveAddresses,
+  descriptorChecksum,
+  hdAccountToDescriptor,
+  hdAccountToDescriptorPair,
+  normalizeMultipathImport,
+  parseDescriptor,
+  siblingChangeDescriptor,
+  verifyDescriptorChecksum
+} from '../src'
+
+/**
+ * Official BIP test vectors — abandon…about (master fpr 73c5da0a).
+ * These are the Sparrow / Bitcoin Core interop anchors for PR1–PR5.
+ */
+const FPR = '73c5da0a'
+const MNEMONIC_NOTE = 'abandon…about'
+
+// Account-level xpubs from UniSat/hdkey (BIP-32 xpub, not SLIP-132 zpub)
+const WPKH_XPUB =
+  'xpub6CatWdiZiodmUeTDp8LT5or8nmbKNcuyvz7WyksVFkKB4RHwCD3XyuvPEbvqAQY3rAPshWcMLoP2fMFMKHPJ4ZeZXYVUhLv1VMrjPC7PW6V'
+const TR_XPUB =
+  'xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ'
+
+describe(`BIP vectors (${MNEMONIC_NOTE})`, () => {
+  it('BIP-84 receive 0/1 and change 0', () => {
+    const pair = hdAccountToDescriptorPair({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: "m/84'/0'/0'" },
+      xpub: WPKH_XPUB
+    })
+    expect(pair.receive.startsWith(`wpkh([${FPR}/84h/0h/0h]${WPKH_XPUB}/0/*)#`)).toBe(true)
+    expect(verifyDescriptorChecksum(pair.receive)).toBe(true)
+    expect(verifyDescriptorChecksum(pair.change)).toBe(true)
+
+    const recv = deriveAddresses(pair.receive, { count: 2 })
+    expect(recv[0]).toBe('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu')
+    expect(recv[1]).toBe('bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g')
+    expect(deriveAddresses(pair.change, { count: 1 })[0]).toBe(
+      'bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el'
+    )
+    expect(siblingChangeDescriptor(pair.receive)).toBe(pair.change)
+  })
+
+  it('BIP-86 taproot receive 0', () => {
+    const receive = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2TR,
+      origin: { fingerprint: FPR, path: "m/86'/0'/0'" },
+      xpub: TR_XPUB,
+      chain: 0
+    })
+    expect(parseDescriptor(receive).kind).toBe('tr')
+    expect(deriveAddresses(receive, { count: 1 })[0]).toBe(
+      'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr'
+    )
+    const change = siblingChangeDescriptor(receive)
+    expect(change).toBeTruthy()
+    expect(change!.includes('/1/*')).toBe(true)
+  })
+
+  it('Sparrow multipath /<0;1>/* expands to BIP-84 receive+change', () => {
+    const multiBody = `wpkh([${FPR}/84h/0h/0h]${WPKH_XPUB}/<0;1>/*)`
+    const multi = `${multiBody}#${descriptorChecksum(multiBody)}`
+    const expanded = normalizeMultipathImport(multi)
+    expect(expanded).toBeTruthy()
+    const pair = hdAccountToDescriptorPair({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: "m/84'/0'/0'" },
+      xpub: WPKH_XPUB
+    })
+    expect(expanded!.receive).toBe(pair.receive)
+    expect(expanded!.change).toBe(pair.change)
+    expect(deriveAddresses(expanded!.receive, { count: 1 })[0]).toBe(
+      'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'
+    )
+  })
+
+  it('checksum flip fails (polymod)', () => {
+    const d = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: '84h/0h/0h' },
+      xpub: WPKH_XPUB
+    })
+    const flipped = d.slice(0, -1) + (d.endsWith('a') ? 'b' : 'a')
+    expect(verifyDescriptorChecksum(flipped)).toBe(false)
+    expect(() => parseDescriptor(flipped)).toThrow(/checksum|invalid/i)
+  })
+
+  it('policy labels are script-type wording', () => {
+    const d = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: '84h/0h/0h' },
+      xpub: WPKH_XPUB
+    })
+    const { policy } = parseDescriptor(d)
+    expect(policy.label.toLowerCase()).toContain('native segwit')
+    expect(policy.label.toLowerCase()).toContain('script')
+    expect(policy.isComplex).toBe(false)
+  })
+})

--- a/packages/descriptor-service/test/checksum.test.ts
+++ b/packages/descriptor-service/test/checksum.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  descriptorChecksum,
+  parseDescriptor,
+  verifyDescriptorChecksum
+} from '../src'
+
+describe('BIP-380 checksum', () => {
+  it('matches BIP vector raw(deadbeef)#89f8spxm', () => {
+    expect(descriptorChecksum('raw(deadbeef)')).toBe('89f8spxm')
+    expect(verifyDescriptorChecksum('raw(deadbeef)#89f8spxm')).toBe(true)
+  })
+
+  it('accepts checksummed wpkh with origin + wildcard', () => {
+    const body =
+      "wpkh([d34db33f/84h/0h/0h]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/0/*)"
+    const raw = `${body}#${descriptorChecksum(body)}`
+    expect(raw.endsWith('#h36s06su')).toBe(true)
+    const parsed = parseDescriptor(raw)
+    expect(parsed.kind).toBe('wpkh')
+    expect(parsed.policy.isComplex).toBe(false)
+  })
+
+  it('rejects missing checksum', () => {
+    expect(() => parseDescriptor('wpkh(xpub...)')).toThrow(/checksum/i)
+  })
+
+  it('rejects bad checksum', () => {
+    expect(() => parseDescriptor('raw(deadbeef)#qqqqqqqq')).toThrow(/invalid/i)
+  })
+
+  it('labels tr() singlesig', () => {
+    const body =
+      'tr([00000000/86h/0h/0h]xpub6BgBgsespWvERF3LHSw6pxgKvJT7WatA4owFbrMx5XfYTSUqvCFK8YrSTHhsrrNyrpCbwrcxdMzvQ5zZHnf8SHPX8KxdQdQdXXjtSGjzzX/0/*)'
+    const raw = `${body}#${descriptorChecksum(body)}`
+    const parsed = parseDescriptor(raw)
+    expect(parsed.kind).toBe('tr')
+    expect(parsed.policy.isComplex).toBe(false)
+  })
+})

--- a/packages/descriptor-service/test/derive.test.ts
+++ b/packages/descriptor-service/test/derive.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DescriptorAddressType,
+  deriveAddresses,
+  hdAccountToDescriptor,
+  hdAccountToDescriptorPair,
+  parseDescriptor
+} from '../src'
+
+// BIP-39 abandon…about — BIP84/86 account-level vectors
+const FPR = '73c5da0a'
+const WPKH_XPUB =
+  'xpub6CatWdiZiodmUeTDp8LT5or8nmbKNcuyvz7WyksVFkKB4RHwCD3XyuvPEbvqAQY3rAPshWcMLoP2fMFMKHPJ4ZeZXYVUhLv1VMrjPC7PW6V'
+const TR_XPUB =
+  'xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ'
+const WPKH_ADDR0 = 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'
+const TR_ADDR0 = 'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr'
+
+describe('hdAccountToDescriptor + deriveAddresses', () => {
+  it('round-trips UniSat Native SegWit (BIP84)', () => {
+    const desc = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: "m/84'/0'/0'" },
+      xpub: WPKH_XPUB,
+      chain: 0
+    })
+    expect(desc.startsWith(`wpkh([${FPR}/84h/0h/0h]${WPKH_XPUB}/0/*)#`)).toBe(true)
+    const parsed = parseDescriptor(desc)
+    expect(parsed.kind).toBe('wpkh')
+    expect(deriveAddresses(desc, { count: 1 })[0]).toBe(WPKH_ADDR0)
+  })
+
+  it('round-trips UniSat Taproot (BIP86)', () => {
+    const desc = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2TR,
+      origin: { fingerprint: FPR, path: '86h/0h/0h' },
+      xpub: TR_XPUB
+    })
+    expect(parseDescriptor(desc).kind).toBe('tr')
+    expect(deriveAddresses(desc, { count: 1 })[0]).toBe(TR_ADDR0)
+  })
+
+  it('builds receive/change pair', () => {
+    const pair = hdAccountToDescriptorPair({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: '84h/0h/0h' },
+      xpub: WPKH_XPUB
+    })
+    expect(pair.receive.includes('/0/*')).toBe(true)
+    expect(pair.change.includes('/1/*')).toBe(true)
+    expect(deriveAddresses(pair.receive)[0]).toBe(WPKH_ADDR0)
+  })
+
+  it('derives a range of addresses', () => {
+    const desc = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: '84h/0h/0h' },
+      xpub: WPKH_XPUB
+    })
+    const addrs = deriveAddresses(desc, { start: 0, count: 3 })
+    expect(addrs).toHaveLength(3)
+    expect(addrs[0]).toBe(WPKH_ADDR0)
+    expect(new Set(addrs).size).toBe(3)
+  })
+
+  it('rejects private xprv material', async () => {
+    const { extractSinglesigKey } = await import('../src')
+    expect(() =>
+      extractSinglesigKey(
+        'wpkh(xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi/0/*)'
+      )
+    ).toThrow(/Private|xprv/i)
+  })
+
+  it('rejects raw multipath in extract; normalize expands Sparrow /<0;1>/*', async () => {
+    const { descriptorChecksum, extractSinglesigKey, normalizeMultipathImport } = await import(
+      '../src'
+    )
+    expect(() => extractSinglesigKey(`wpkh(${WPKH_XPUB}/<0;1>/*)`)).toThrow(/Multipath|normalize/i)
+    expect(() => extractSinglesigKey(`wpkh(${WPKH_XPUB}/0h/*)`)).toThrow(/Hardened/i)
+
+    const multiBody = `wpkh([${FPR}/84h/0h/0h]${WPKH_XPUB}/<0;1>/*)`
+    const multi = `${multiBody}#${descriptorChecksum(multiBody)}`
+    const expanded = normalizeMultipathImport(multi)
+    expect(expanded).toBeTruthy()
+    expect(expanded!.receive.includes('/0/*')).toBe(true)
+    expect(expanded!.change.includes('/1/*')).toBe(true)
+    expect(deriveAddresses(expanded!.receive, { count: 1 })[0]).toBe(WPKH_ADDR0)
+    expect(normalizeMultipathImport(expanded!.receive)).toBeNull()
+  })
+
+  it('rejects exotic multipath and out-of-range derive indices', async () => {
+    const { descriptorChecksum, normalizeMultipathImport } = await import('../src')
+    const badBody = `wpkh([${FPR}/84h/0h/0h]${WPKH_XPUB}/<1;0>/*)`
+    const bad = `${badBody}#${descriptorChecksum(badBody)}`
+    expect(() => normalizeMultipathImport(bad)).toThrow(/multipath|Sparrow/i)
+
+    const desc = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: '84h/0h/0h' },
+      xpub: WPKH_XPUB
+    })
+    expect(() => deriveAddresses(desc, { start: -1, count: 1 })).toThrow(/start/i)
+    expect(() => deriveAddresses(desc, { start: 0x7fffffff, count: 2 })).toThrow(/index|start\+count/i)
+    expect(() => deriveAddresses(desc, { network: 'testnet', count: 1 })).toThrow(/network|xpub|tpub/i)
+  })
+
+  it('rejects fixed-path descriptors without /* (no silent wrong gap)', async () => {
+    const { descriptorChecksum } = await import('../src')
+    const body = `wpkh(${WPKH_XPUB}/0/0)`
+    const fixed = `${body}#${descriptorChecksum(body)}`
+    expect(() => deriveAddresses(fixed, { count: 2 })).toThrow(/Ranged|\/\*/i)
+  })
+
+  it('rejects origin-path /* phishing (wildcard only after xpub)', async () => {
+    const { descriptorChecksum, extractSinglesigKey } = await import('../src')
+    // Crafted: /* sits inside origin; key expr is fixed /0/0 — must not derive a fake gap
+    const body = `wpkh([${FPR}/84h/*/0h]${WPKH_XPUB}/0/0)`
+    const crafted = `${body}#${descriptorChecksum(body)}`
+    expect(() => deriveAddresses(crafted, { count: 2 })).toThrow()
+    expect(() => extractSinglesigKey(body)).toThrow()
+  })
+
+  it('rejects non-standard chain wildcards like /2/*', async () => {
+    const { extractSinglesigKey } = await import('../src')
+    expect(() => extractSinglesigKey(`wpkh(${WPKH_XPUB}/2/*)`)).toThrow(/\/\*|0\/\*|1\/\*/i)
+  })
+
+  it('rejects SLIP-132 with a clear error', async () => {
+    const { extractSinglesigKey } = await import('../src')
+    expect(() =>
+      extractSinglesigKey(
+        'wpkh(zpub6rFR7y4Q2PFmgxNfZRFeATDvyUyQpcnEd3fxeiwq884RgE8zxX5NwGLhD8y4K6zqH4xK5vQxJzqH4xK5vQxJzqH4xK5vQxJzqH4xK5vQxJ/0/*)'
+      )
+    ).toThrow(/SLIP-132|zpub/i)
+  })
+
+  it('builds chain-level descriptor (OW short path)', () => {
+    const desc = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2TR,
+      origin: { fingerprint: FPR, path: "m/86'/0'/0'" },
+      xpub: TR_XPUB,
+      xpubLevel: 'chain'
+    })
+    expect(desc.includes(`${TR_XPUB}/*)#`)).toBe(true)
+    expect(desc.includes('/0/*')).toBe(false)
+  })
+
+  it('builds sibling change descriptor from receive', async () => {
+    const { siblingChangeDescriptor } = await import('../src')
+    const receive = hdAccountToDescriptor({
+      addressType: DescriptorAddressType.P2WPKH,
+      origin: { fingerprint: FPR, path: '84h/0h/0h' },
+      xpub: WPKH_XPUB,
+      chain: 0
+    })
+    const change = siblingChangeDescriptor(receive)
+    expect(change).toBeTruthy()
+    expect(change!.includes('/1/*')).toBe(true)
+    expect(parseDescriptor(change!).kind).toBe('wpkh')
+  })
+})

--- a/packages/descriptor-service/tsconfig.json
+++ b/packages/descriptor-service/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/descriptor-service/tsup.config.ts
+++ b/packages/descriptor-service/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  outDir: 'lib',
+  target: 'es2020'
+})

--- a/packages/descriptor-service/vitest.config.ts
+++ b/packages/descriptor-service/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.{test,spec}.ts']
+  }
+})

--- a/packages/keyring-service/package.json
+++ b/packages/keyring-service/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@keystonehq/keystone-sdk": "^0.3.0",
     "@metamask/obs-store": "^7.0.0",
+    "@unisat/descriptor-service": "workspace:*",
     "@unisat/wallet-bitcoin": "workspace:*",
     "@unisat/wallet-shared": "workspace:*",
     "@unisat/wallet-storage": "workspace:*",

--- a/packages/keyring-service/src/index.ts
+++ b/packages/keyring-service/src/index.ts
@@ -7,6 +7,7 @@ export {
   HdKeyring,
   KeystoneKeyring,
   ColdWalletKeyring,
+  WatchAddressKeyring,
   isKeystoneSupportedHdPath,
   KEYSTONE_SUPPORTED_HD_PATH,
 } from './keyrings'

--- a/packages/keyring-service/src/keyrings/cold-wallet-keyring.ts
+++ b/packages/keyring-service/src/keyrings/cold-wallet-keyring.ts
@@ -1,6 +1,13 @@
 import { bitcoin } from '@unisat/wallet-bitcoin'
 import { CosmosSignDataType, Keyring, KeyringType, ToSignInput } from '../types'
 
+function normalizeOptionalFingerprint(raw?: string): string | undefined {
+  if (!raw) return undefined
+  const hex = raw.trim().toLowerCase().replace(/^0x/, '')
+  if (!/^[0-9a-f]{8}$/.test(hex) || /^0+$/.test(hex)) return undefined
+  return hex
+}
+
 export interface ColdWalletKeyringOptions {
   xpub: string
   addresses: string[]
@@ -8,6 +15,8 @@ export interface ColdWalletKeyringOptions {
   hdPath?: string
   publicKeys?: string[]
   accounts?: { pubkey: string; address: string }[]
+  /** 8-hex master fingerprint when known (from QR / hardware); omit if unknown */
+  fingerprint?: string
 }
 
 export class ColdWalletKeyring implements Keyring {
@@ -19,6 +28,7 @@ export class ColdWalletKeyring implements Keyring {
   hdPath?: string = undefined
   publicKeys?: string[] = undefined
   accounts?: string[] = undefined
+  fingerprint?: string = undefined
 
   constructor(opts?: ColdWalletKeyringOptions) {
     if (!opts) {
@@ -36,6 +46,7 @@ export class ColdWalletKeyring implements Keyring {
     this.addresses = opts.addresses || []
     this.connectionType = opts.connectionType || 'QR'
     this.hdPath = opts.hdPath || ''
+    this.fingerprint = normalizeOptionalFingerprint(opts.fingerprint)
 
     // Deal with publicKeys, compatible with the old version of accounts format
     if (opts.publicKeys) {
@@ -53,6 +64,7 @@ export class ColdWalletKeyring implements Keyring {
       connectionType: this.connectionType,
       hdPath: this.hdPath || '',
       publicKeys: this.publicKeys || [],
+      fingerprint: this.fingerprint || '',
     }
   }
 
@@ -65,6 +77,7 @@ export class ColdWalletKeyring implements Keyring {
     this.addresses = opts.addresses || []
     this.connectionType = opts.connectionType || 'QR'
     this.hdPath = opts.hdPath || ''
+    this.fingerprint = normalizeOptionalFingerprint(opts.fingerprint)
 
     if (opts.publicKeys) {
       this.publicKeys = opts.publicKeys

--- a/packages/keyring-service/src/keyrings/hd-keyring.ts
+++ b/packages/keyring-service/src/keyrings/hd-keyring.ts
@@ -124,6 +124,76 @@ export class HdKeyring extends SimpleKeyring {
     this.passphrase = ''
   }
 
+  /**
+   * Watch-only descriptor material: master fingerprint + account-level xpub.
+   * UniSat hdPath is typically m/purpose'/coin'/account'/change — account path drops change.
+   * Short paths (e.g. Ordinals Wallet `m/86'/0'/0'` with no change segment) use xpubLevel
+   * `chain` so export is `…xpub/*` (children = wallet addresses), not wrong `…/0/*`.
+   *
+   * Fingerprint is only returned for mnemonic-rooted keyrings (true master fpr).
+   * xpriv-only roots omit fingerprint — never emit a wrong `[fpr/…]` origin.
+   */
+  getAccountXpubMaterial(accountIndex = 0): {
+    fingerprint?: string
+    accountPath: string
+    xpub: string
+    /** `account` → descriptor `xpub/0/*`; `chain` → `xpub/*` (no separate change) */
+    xpubLevel: 'account' | 'chain'
+  } {
+    if (!this.hdWallet) {
+      throw new Error('Btc-Hd-Keyring: Not support')
+    }
+
+    // m / purpose' / coin' / account' [/ change]
+    const hasChangeSegment = this.hdPath.split('/').length >= 5
+    const xpubLevel: 'account' | 'chain' = hasChangeSegment ? 'account' : 'chain'
+
+    // Multi-account short path: wallet only uses /0 per account', but chain-level
+    // export would advertise xpub/* — refuse rather than misrepresent the address set.
+    if (this.accountIndexDerivation && xpubLevel === 'chain') {
+      throw new Error(
+        'Cannot export a ranged descriptor for multi-account short-path wallets; use a standard BIP path that includes a change segment'
+      )
+    }
+
+    let accountPath: string
+    if (this.accountIndexDerivation) {
+      accountPath = this._buildAccountLevelPath(this.hdPath, accountIndex)
+      // drop trailing change segment if present
+      const parts = accountPath.split('/')
+      if (parts.length >= 5) {
+        accountPath = parts.slice(0, 4).join('/')
+      }
+    } else {
+      const parts = this.hdPath.split('/')
+      if (parts.length >= 5) {
+        accountPath = parts.slice(0, 4).join('/')
+      } else {
+        accountPath = this.hdPath
+      }
+    }
+
+    const accountNode = this.hdWallet.derive(accountPath)
+
+    // Master fingerprint only when rooted at mnemonic seed (hdWallet = master).
+    // xpriv-imported nodes expose the node's own identifier — not the master fpr.
+    let fingerprint: string | undefined
+    if (this.mnemonic) {
+      const identifier: Buffer = this.hdWallet.identifier || this.hdWallet._identifier
+      if (!identifier || identifier.length < 4) {
+        throw new Error('Btc-Hd-Keyring: master fingerprint unavailable')
+      }
+      fingerprint = Buffer.from(identifier).subarray(0, 4).toString('hex')
+    }
+
+    return {
+      ...(fingerprint ? { fingerprint } : {}),
+      accountPath,
+      xpub: accountNode.publicExtendedKey,
+      xpubLevel,
+    }
+  }
+
   changeHdPath(hdPath: string) {
     if (!this.hdWallet) {
       throw new Error('Btc-Hd-Keyring: Not support')

--- a/packages/keyring-service/src/keyrings/watch-address-keyring.ts
+++ b/packages/keyring-service/src/keyrings/watch-address-keyring.ts
@@ -1,20 +1,82 @@
+import { deriveAddresses, type DescriptorNetwork } from '@unisat/descriptor-service'
 import { Keyring, KeyringType, ToSignInput } from '../types'
 
+export interface WatchAddressKeyringData {
+  addresses: string[]
+  /** Receive descriptor — enables live gap expansion via addAccounts */
+  descriptor?: string
+  changeDescriptor?: string
+  network?: DescriptorNetwork
+  /**
+   * Count of receive addresses in `addresses` derived from `descriptor`.
+   * Gap expansion uses this (not addresses.length) so future change entries
+   * cannot corrupt the receive start index.
+   */
+  receiveCount?: number
+}
+
+function isWatchData(opts: unknown): opts is WatchAddressKeyringData {
+  return !!opts && typeof opts === 'object' && !Array.isArray(opts) && 'addresses' in (opts as object)
+}
+
+/**
+ * Watch-only addresses. Optionally stores a BIP-380 descriptor so more
+ * receive addresses can be derived later (gap discovery) without private keys.
+ *
+ * Invariant: when `descriptor` is set, `addresses[0..receiveCount)` are receive
+ * addresses from that descriptor (change is never mixed into this prefix).
+ */
 export class WatchAddressKeyring implements Keyring {
   static type = KeyringType.WatchAddressKeyring
   type = KeyringType.WatchAddressKeyring
   addresses: string[] = []
+  descriptor?: string
+  changeDescriptor?: string
+  network: DescriptorNetwork = 'mainnet'
+  /** Length of the receive prefix in `addresses` (see class invariant). */
+  receiveCount = 0
 
-  constructor(addresses: string[]) {
-    this.addresses = addresses
+  constructor(opts?: string[] | WatchAddressKeyringData) {
+    if (Array.isArray(opts)) {
+      this.addresses = opts.filter(Boolean)
+      this.receiveCount = this.addresses.length
+      return
+    }
+    if (isWatchData(opts)) {
+      this.addresses = [...(opts.addresses || [])]
+      this.descriptor = opts.descriptor
+      this.changeDescriptor = opts.changeDescriptor
+      this.network = opts.network || 'mainnet'
+      this.receiveCount =
+        typeof opts.receiveCount === 'number' ? opts.receiveCount : this.addresses.length
+    }
   }
 
   async getAccounts(): Promise<string[]> {
     return this.addresses
   }
 
-  async addAccounts(_n: number): Promise<string[]> {
-    throw new Error('Method not implemented.')
+  /**
+   * Derive the next `n` receive addresses from the stored descriptor.
+   * Returns the new addresses (same contract as other keyrings' addAccounts).
+   */
+  async addAccounts(n: number): Promise<string[]> {
+    if (!this.descriptor) {
+      throw new Error(
+        'This watch wallet has no stored descriptor. Re-import a descriptor to enable gap discovery.'
+      )
+    }
+    if (n < 1) return []
+    const start = this.receiveCount
+    const more = deriveAddresses(this.descriptor, {
+      network: this.network,
+      start,
+      count: n,
+    })
+    // Insert after receive prefix (preserve any trailing non-receive entries)
+    this.addresses.splice(this.receiveCount, 0, ...more)
+    this.receiveCount += more.length
+    return more
   }
 
   signTransaction(_psbt: any, _inputs: ToSignInput[]): Promise<any> {
@@ -37,11 +99,43 @@ export class WatchAddressKeyring implements Keyring {
     throw new Error('Method not implemented.')
   }
 
-  async serialize() {
-    return this.addresses.join(',')
+  async serialize(): Promise<string | WatchAddressKeyringData> {
+    // Legacy string form when no descriptor (single-address watch imports)
+    if (!this.descriptor && !this.changeDescriptor) {
+      return this.addresses.join(',')
+    }
+    return {
+      addresses: this.addresses,
+      descriptor: this.descriptor,
+      changeDescriptor: this.changeDescriptor,
+      network: this.network,
+      receiveCount: this.receiveCount,
+    }
   }
 
-  async deserialize(opts: any) {
-    this.addresses = opts ? opts.split(',') : []
+  async deserialize(opts: string | WatchAddressKeyringData): Promise<void> {
+    if (typeof opts === 'string') {
+      this.addresses = opts ? opts.split(',').filter(Boolean) : []
+      this.descriptor = undefined
+      this.changeDescriptor = undefined
+      this.network = 'mainnet'
+      this.receiveCount = this.addresses.length
+      return
+    }
+    if (isWatchData(opts)) {
+      this.addresses = [...(opts.addresses || [])]
+      this.descriptor = opts.descriptor
+      this.changeDescriptor = opts.changeDescriptor
+      this.network = opts.network || 'mainnet'
+      this.receiveCount =
+        typeof opts.receiveCount === 'number' ? opts.receiveCount : this.addresses.length
+      return
+    }
+    this.addresses = []
+    this.receiveCount = 0
+  }
+
+  hasDescriptor(): boolean {
+    return !!this.descriptor
   }
 }

--- a/packages/keyring-service/test/hd-keyring-descriptor.test.ts
+++ b/packages/keyring-service/test/hd-keyring-descriptor.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { HdKeyring } from '../src/keyrings/hd-keyring'
+
+const MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+
+describe('HdKeyring.getAccountXpubMaterial', () => {
+  it('returns BIP84 account-level xpub + fingerprint', () => {
+    const keyring = new HdKeyring({
+      mnemonic: MNEMONIC,
+      hdPath: "m/84'/0'/0'/0",
+      activeIndexes: [0]
+    })
+    const material = keyring.getAccountXpubMaterial()
+    expect(material.fingerprint).toBe('73c5da0a')
+    expect(material.accountPath).toBe("m/84'/0'/0'")
+    expect(material.xpubLevel).toBe('account')
+    expect(material.xpub).toBe(
+      'xpub6CatWdiZiodmUeTDp8LT5or8nmbKNcuyvz7WyksVFkKB4RHwCD3XyuvPEbvqAQY3rAPshWcMLoP2fMFMKHPJ4ZeZXYVUhLv1VMrjPC7PW6V'
+    )
+  })
+
+  it('returns BIP86 account-level xpub', () => {
+    const keyring = new HdKeyring({
+      mnemonic: MNEMONIC,
+      hdPath: "m/86'/0'/0'/0",
+      activeIndexes: [0]
+    })
+    const material = keyring.getAccountXpubMaterial()
+    expect(material.fingerprint).toBe('73c5da0a')
+    expect(material.accountPath).toBe("m/86'/0'/0'")
+    expect(material.xpubLevel).toBe('account')
+    expect(material.xpub).toBe(
+      'xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ'
+    )
+  })
+
+  it('uses chain-level xpub for short OW-style path without change segment', () => {
+    const keyring = new HdKeyring({
+      mnemonic: MNEMONIC,
+      hdPath: "m/86'/0'/0'",
+      activeIndexes: [0]
+    })
+    const material = keyring.getAccountXpubMaterial()
+    expect(material.xpubLevel).toBe('chain')
+    expect(material.accountPath).toBe("m/86'/0'/0'")
+    expect(material.fingerprint).toBe('73c5da0a')
+  })
+
+  it('refuses multi-account short-path ranged export', () => {
+    const keyring = new HdKeyring({
+      mnemonic: MNEMONIC,
+      hdPath: "m/86'/0'/0'",
+      activeIndexes: [0],
+      accountIndexDerivation: true
+    })
+    expect(() => keyring.getAccountXpubMaterial(0)).toThrow(/multi-account short-path/i)
+  })
+
+  it('omits fingerprint for xpriv-only roots (never invent wrong origin)', () => {
+    const fromMnemonic = new HdKeyring({
+      mnemonic: MNEMONIC,
+      hdPath: "m/84'/0'/0'/0",
+      activeIndexes: [0]
+    })
+    // Account-level xpriv would be wrong as "master"; use the account node xpriv
+    // via serialize is hard — instead build from known account xpriv of abandon seed.
+    // Root master xpriv: fingerprint would still be of that node if not mnemonic-rooted.
+    const master = fromMnemonic as any
+    const xpriv = master.hdWallet.privateExtendedKey as string
+    const xprivOnly = new HdKeyring({
+      xpriv,
+      hdPath: "m/84'/0'/0'/0",
+      activeIndexes: [0]
+    })
+    const material = xprivOnly.getAccountXpubMaterial()
+    expect(material.fingerprint).toBeUndefined()
+    expect(material.xpub).toBeTruthy()
+  })
+})

--- a/packages/keyring-service/test/watch-address-descriptor.test.ts
+++ b/packages/keyring-service/test/watch-address-descriptor.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DescriptorAddressType,
+  deriveAddresses,
+  hdAccountToDescriptor
+} from '@unisat/descriptor-service'
+import { WatchAddressKeyring } from '../src/keyrings/watch-address-keyring'
+
+const FPR = '73c5da0a'
+const WPKH_XPUB =
+  'xpub6CatWdiZiodmUeTDp8LT5or8nmbKNcuyvz7WyksVFkKB4RHwCD3XyuvPEbvqAQY3rAPshWcMLoP2fMFMKHPJ4ZeZXYVUhLv1VMrjPC7PW6V'
+const WPKH_ADDR0 = 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'
+
+describe('WatchAddressKeyring descriptor gap', () => {
+  const descriptor = hdAccountToDescriptor({
+    addressType: DescriptorAddressType.P2WPKH,
+    origin: { fingerprint: FPR, path: "m/84'/0'/0'" },
+    xpub: WPKH_XPUB,
+    chain: 0
+  })
+
+  it('stores descriptor and expands gap via addAccounts', async () => {
+    const initial = deriveAddresses(descriptor, { network: 'mainnet', start: 0, count: 3 })
+    expect(initial[0]).toBe(WPKH_ADDR0)
+
+    const keyring = new WatchAddressKeyring({
+      addresses: initial,
+      descriptor,
+      network: 'mainnet'
+    })
+
+    expect(keyring.hasDescriptor()).toBe(true)
+    expect(await keyring.getAccounts()).toHaveLength(3)
+
+    const added = await keyring.addAccounts(2)
+    expect(added).toHaveLength(2)
+    const all = await keyring.getAccounts()
+    expect(all).toHaveLength(5)
+
+    const expected = deriveAddresses(descriptor, { network: 'mainnet', start: 0, count: 5 })
+    expect(all).toEqual(expected)
+  })
+
+  it('round-trips JSON serialize with descriptor (not legacy CSV)', async () => {
+    const initial = deriveAddresses(descriptor, { network: 'mainnet', start: 0, count: 2 })
+    const keyring = new WatchAddressKeyring({
+      addresses: initial,
+      descriptor,
+      network: 'mainnet'
+    })
+    const serialized = await keyring.serialize()
+    expect(typeof serialized).toBe('object')
+
+    const restored = new WatchAddressKeyring()
+    await restored.deserialize(serialized as any)
+    expect(restored.hasDescriptor()).toBe(true)
+    expect(await restored.getAccounts()).toEqual(initial)
+    await restored.addAccounts(1)
+    expect(await restored.getAccounts()).toHaveLength(3)
+  })
+
+  it('keeps legacy CSV deserialize for plain address watches', async () => {
+    const keyring = new WatchAddressKeyring()
+    await keyring.deserialize(
+      'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh,bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'
+    )
+    expect(keyring.hasDescriptor()).toBe(false)
+    expect(await keyring.getAccounts()).toHaveLength(2)
+    await expect(keyring.addAccounts(1)).rejects.toThrow(/no stored descriptor/i)
+  })
+
+  it('gap expansion uses receiveCount, not addresses.length', async () => {
+    const initial = deriveAddresses(descriptor, { network: 'mainnet', start: 0, count: 2 })
+    const keyring = new WatchAddressKeyring({
+      addresses: [...initial, 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh'],
+      descriptor,
+      network: 'mainnet',
+      receiveCount: 2
+    })
+    const added = await keyring.addAccounts(1)
+    const expected2 = deriveAddresses(descriptor, { network: 'mainnet', start: 2, count: 1 })[0]
+    expect(added[0]).toBe(expected2)
+    expect(keyring.receiveCount).toBe(3)
+    expect(await keyring.getAccounts()).toHaveLength(4)
+  })
+})

--- a/packages/tx-helpers/test/send-btc.test.ts
+++ b/packages/tx-helpers/test/send-btc.test.ts
@@ -287,6 +287,27 @@ describe('sendBTC', () => {
     })
   })
 
+  describe('safe UTXO (descriptor integration regression)', function () {
+    it('rejects inscription-bearing UTXOs with NOT_SAFE_UTXOS', async function () {
+      const wallet = LocalWallet.fromRandom(AddressType.P2WPKH, NetworkType.MAINNET)
+      await expect(
+        sendBTC({
+          btcUtxos: [
+            genDummyUtxo(wallet, 10000, {
+              inscriptions: [{ inscriptionId: 'i0', offset: 0 }],
+            }),
+          ],
+          tos: [{ address: wallet.address, satoshis: 1000 }],
+          networkType: NetworkType.MAINNET,
+          changeAddress: wallet.address,
+          feeRate: 1,
+        })
+      ).rejects.toMatchObject({
+        code: ErrorCodes.NOT_SAFE_UTXOS,
+      })
+    })
+  })
+
   describe('P2PKH', function () {
     const wallet_P2WPKH = LocalWallet.fromRandom(AddressType.P2WPKH, NetworkType.MAINNET)
     const wallet_P2PKH = LocalWallet.fromRandom(AddressType.P2PKH, NetworkType.MAINNET)

--- a/packages/wallet-background/package.json
+++ b/packages/wallet-background/package.json
@@ -34,6 +34,7 @@
   "peerDependencies": {
     "@unisat/babylon-service": "workspace:*",
     "@unisat/contact-book": "workspace:*",
+    "@unisat/descriptor-service": "workspace:*",
     "@unisat/keyring-service": "workspace:*",
     "@unisat/permission-service": "workspace:*",
     "@unisat/phishing-detect": "workspace:*",
@@ -48,6 +49,7 @@
     "@unisat/wallet-shared": "workspace:*"
   },
   "dependencies": {
+    "@unisat/descriptor-service": "workspace:*",
     "bignumber.js": "^9.1.1",
     "bitcore-lib": "^10.0.0",
     "compare-versions": "^4.1.3",

--- a/packages/wallet-background/src/controllers/wallet.ts
+++ b/packages/wallet-background/src/controllers/wallet.ts
@@ -10,10 +10,25 @@ import {
   getDelegationsV2,
 } from '@unisat/babylon-service'
 import {
+  addressTypeHintFromKind,
+  DescriptorAddressType,
+  DescriptorError,
+  descriptorBodyWithoutOrigin,
+  deriveAddresses,
+  extractSinglesigKey,
+  hdAccountToDescriptor,
+  parseDescriptor,
+  PolicySummary,
+  normalizeMultipathImport,
+  siblingChangeDescriptor,
+} from '@unisat/descriptor-service'
+import {
   ColdWalletKeyring,
+  HdKeyring,
   isKeystoneSupportedHdPath,
   KEYSTONE_SUPPORTED_HD_PATH,
   KeystoneKeyring,
+  WatchAddressKeyring,
 } from '@unisat/keyring-service'
 import { DisplayedKeyring, Keyring, KeyringType, ToSignInput } from '@unisat/keyring-service/types'
 import * as txHelpers from '@unisat/tx-helpers'
@@ -639,8 +654,12 @@ export class WalletController extends BaseController {
     addressType: AddressType,
     alianName?: string,
     hdPath?: string,
-    accountCount = 1
+    accountCount = 1,
+    fingerprint?: string
   ) => {
+    if (hdPath) {
+      this._assertColdXpubPathDepth(xpub, hdPath)
+    }
     const accounts = await this.deriveAccountsFromXpub(xpub, addressType, hdPath, accountCount)
     const addresses = accounts.map(acc => acc.address)
     const publicKeys = accounts.map(acc => acc.pubkey)
@@ -651,6 +670,7 @@ export class WalletController extends BaseController {
       connectionType: 'QR',
       hdPath: hdPath!,
       publicKeys,
+      ...(fingerprint ? { fingerprint } : {}),
     })
 
     const originKeyring = await keyringService.addKeyring(coldWalletKeyring, addressType)
@@ -723,7 +743,16 @@ export class WalletController extends BaseController {
   }
 
   deriveNewAccountFromMnemonic = async (keyring: WalletKeyring, alianName?: string) => {
-    if (keyring.type !== KeyringType.HdKeyring && keyring.type !== KeyringType.KeystoneKeyring) {
+    const origin = keyringService.keyrings[keyring.index]
+    const canExpandWatch =
+      keyring.type === KeyringType.WatchAddressKeyring &&
+      origin instanceof WatchAddressKeyring &&
+      origin.hasDescriptor()
+    if (
+      keyring.type !== KeyringType.HdKeyring &&
+      keyring.type !== KeyringType.KeystoneKeyring &&
+      !canExpandWatch
+    ) {
       throw new Error(t('not_supported'))
     }
     const _keyring = keyringService.keyrings[keyring.index]!
@@ -3587,6 +3616,424 @@ export class WalletController extends BaseController {
   getBTCUnit() {
     const chainType = this.getChainType()
     return CHAINS_MAP[chainType]!.unit
+  }
+
+  private _toDescriptorAddressType(addressType: AddressType): DescriptorAddressType {
+    // Explicit map — never rely on numeric enum coincidence with DescriptorAddressType
+    const map: Partial<Record<AddressType, DescriptorAddressType>> = {
+      [AddressType.P2PKH]: DescriptorAddressType.P2PKH,
+      [AddressType.P2WPKH]: DescriptorAddressType.P2WPKH,
+      [AddressType.P2TR]: DescriptorAddressType.P2TR,
+      [AddressType.P2SH_P2WPKH]: DescriptorAddressType.P2SH_P2WPKH,
+    }
+    const mapped = map[addressType]
+    if (mapped !== undefined) return mapped
+    // Deprecated UniSat M44+segwit/taproot uses purpose 44' with non-BIP script
+    if (addressType === AddressType.M44_P2WPKH || addressType === AddressType.M44_P2TR) {
+      throw new Error(
+        'Legacy M44 address type uses non-standard derivation; switch to Native SegWit or Taproot to export a BIP-compatible descriptor'
+      )
+    }
+    throw new Error('Address type does not support descriptor export')
+  }
+
+  private _descriptorNetwork(): 'mainnet' | 'testnet' | 'regtest' {
+    const n = this.getNetworkType()
+    if (n === NetworkType.TESTNET) return 'testnet'
+    if (n === NetworkType.REGTEST) return 'regtest'
+    return 'mainnet'
+  }
+
+  /** Descriptors are Bitcoin BIP-380 — not defined for Fractal chain params. */
+  private _assertBitcoinDescriptorChain(): void {
+    const chain = CHAINS_MAP[this.getChainType()]
+    if (chain?.isFractal) {
+      throw new Error(
+        'Descriptor export/import is only supported on Bitcoin networks (not Fractal)'
+      )
+    }
+  }
+
+  /** Fail closed when cold QR path depth ≠ xpub depth (wrong origin in Sparrow/PSBT). */
+  private _assertColdXpubPathDepth(xpub: string, hdPath: string): void {
+    let depth: number
+    try {
+      depth = new bitcore.HDPublicKey(xpub).depth
+    } catch {
+      throw new Error('Invalid cold wallet xpub')
+    }
+    const segments = hdPath
+      .replace(/^m\/?/, '')
+      .split('/')
+      .filter(Boolean).length
+    if (depth !== segments) {
+      throw new Error(
+        `Cold wallet xpub depth (${depth}) does not match hdPath (${hdPath}); refusing mismatched descriptor origin`
+      )
+    }
+  }
+
+  private _parseImportDescriptor(
+    rawDescriptor: string,
+    accountCount: number
+  ): {
+    trimmed: string
+    addressType: AddressType
+    network: 'mainnet' | 'testnet' | 'regtest'
+    addresses: string[]
+    policy: PolicySummary
+    changeDescriptor?: string
+    previewAddresses: string[]
+  } {
+    let trimmed = rawDescriptor.trim()
+    if (/(?:^|[[(,/\s])([xtyuz]prv)/i.test(trimmed)) {
+      throw new Error('Private descriptors are not allowed; paste a watch-only xpub descriptor')
+    }
+
+    // Sparrow default: …/<0;1>/* → expand to receive /0/* + change /1/* before derive
+    let changeDescriptor: string | undefined
+    try {
+      const multipath = normalizeMultipathImport(trimmed)
+      if (multipath) {
+        trimmed = multipath.receive
+        changeDescriptor = multipath.change
+      }
+    } catch (e) {
+      if (e instanceof DescriptorError) {
+        throw new Error(e.message)
+      }
+      throw e
+    }
+
+    let parsed
+    try {
+      parsed = parseDescriptor(trimmed)
+    } catch (e) {
+      if (e instanceof DescriptorError) {
+        throw new Error(e.message)
+      }
+      throw e
+    }
+
+    const keyBody = descriptorBodyWithoutOrigin(parsed.body)
+    if (!keyBody.includes('/*')) {
+      throw new Error('Ranged descriptor required (must include /*), e.g. …/0/*)#checksum')
+    }
+    if (keyBody.includes('/1/*') && !keyBody.includes('/0/*')) {
+      throw new Error('Paste the receive descriptor (…/0/*), not a change-only descriptor (…/1/*)')
+    }
+
+    const { kind, xpub, chainPath } = extractSinglesigKey(parsed.body)
+    if (chainPath === '1') {
+      throw new Error('Paste the receive descriptor (…/0/*), not a change-only descriptor (…/1/*)')
+    }
+    const hint = addressTypeHintFromKind(kind)
+    const addressTypeMap: Record<string, AddressType> = {
+      P2WPKH: AddressType.P2WPKH,
+      P2TR: AddressType.P2TR,
+      P2SH_P2WPKH: AddressType.P2SH_P2WPKH,
+      P2PKH: AddressType.P2PKH,
+    }
+    const addressType = addressTypeMap[hint]
+    if (addressType === undefined) {
+      throw new Error('Unsupported descriptor script type')
+    }
+
+    const count = Math.min(Math.max(accountCount, 1), 100)
+    const network = this._descriptorNetwork()
+    const isTestPub = /\btpub/.test(xpub)
+    if (network === 'mainnet' && isTestPub) {
+      throw new Error(
+        'This descriptor uses a testnet xpub (tpub); switch network or paste a mainnet descriptor'
+      )
+    }
+    if (network !== 'mainnet' && !isTestPub) {
+      throw new Error(
+        'This descriptor uses a mainnet xpub (xpub); switch to Bitcoin mainnet or paste a tpub descriptor'
+      )
+    }
+    const addresses = deriveAddresses(trimmed, {
+      network,
+      start: 0,
+      count,
+    })
+    if (!addresses.length) {
+      throw new Error('No addresses derived from descriptor')
+    }
+
+    if (!changeDescriptor) {
+      try {
+        changeDescriptor = siblingChangeDescriptor(trimmed)
+      } catch {
+        changeDescriptor = undefined
+      }
+    }
+
+    return {
+      trimmed,
+      addressType,
+      network,
+      addresses,
+      policy: parsed.policy,
+      ...(changeDescriptor ? { changeDescriptor } : {}),
+      previewAddresses: addresses.slice(0, 3),
+    }
+  }
+
+  /**
+   * Preview a watch-only descriptor without persisting (confirm addresses before import).
+   */
+  previewDescriptor = async (
+    rawDescriptor: string,
+    accountCount = 20
+  ): Promise<{
+    policy: PolicySummary
+    previewAddresses: string[]
+    addressType: AddressType
+    network: string
+    watchOnly: true
+  }> => {
+    this._assertBitcoinDescriptorChain()
+    const parsed = this._parseImportDescriptor(rawDescriptor, accountCount)
+    return {
+      policy: parsed.policy,
+      previewAddresses: parsed.previewAddresses,
+      addressType: parsed.addressType,
+      network: parsed.network,
+      watchOnly: true,
+    }
+  }
+
+  /** Whether Advanced → Export descriptor should be offered for the current keyring. */
+  canExportAccountDescriptor = async (): Promise<boolean> => {
+    try {
+      this._assertBitcoinDescriptorChain()
+      const keyring = await this.getCurrentKeyring()
+      if (!keyring) return false
+      if (keyring.type === KeyringType.HdKeyring || keyring.type === KeyringType.ColdWalletKeyring) {
+        return true
+      }
+      if (keyring.type === KeyringType.WatchAddressKeyring) {
+        const origin = keyringService.keyrings[keyring.index] as WatchAddressKeyring
+        return Boolean(origin?.hasDescriptor?.())
+      }
+      return false
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Export a BIP-380 watch-only descriptor for the current (or given) keyring.
+   * Never includes private keys.
+   */
+  exportAccountDescriptor = async (opts?: {
+    keyringIndex?: number
+    /** UI account slot when exporting a non-current keyring with accountIndexDerivation */
+    accountSlot?: number
+    chain?: 0 | 1
+  }): Promise<{
+    descriptor: string
+    changeDescriptor?: string
+    policy: PolicySummary
+    watchOnly: true
+    /** Account-level xpub (HD) or chain-level xpub (cold); never xprv */
+    xpub?: string
+    accountPath?: string
+    fingerprint?: string
+  }> => {
+    this._assertBitcoinDescriptorChain()
+    const keyrings = await this.getKeyrings()
+    const keyring =
+      opts?.keyringIndex !== undefined
+        ? keyrings[opts.keyringIndex]
+        : await this.getCurrentKeyring()
+    if (!keyring || !('addressType' in keyring)) {
+      throw new Error('No keyring')
+    }
+
+    const addressType = this._toDescriptorAddressType(keyring.addressType)
+    const chain = opts?.chain ?? 0
+
+    if (keyring.type === KeyringType.HdKeyring) {
+      const origin = keyringService.keyrings[keyring.index] as HdKeyring
+      if (!origin?.getAccountXpubMaterial) {
+        throw new Error('HD keyring unavailable')
+      }
+      // When accountIndexDerivation is on, map UI slot → BIP account' via activeIndexes.
+      // Prefer explicit accountSlot; else only use current account when exporting the
+      // current keyring (never borrow another keyring's slot).
+      let accountIndex = 0
+      if (origin.accountIndexDerivation) {
+        let slot = opts?.accountSlot
+        if (slot === undefined) {
+          const currentKeyring = await this.getCurrentKeyring()
+          const current = await this.getCurrentAccount()
+          if (
+            currentKeyring?.index === keyring.index &&
+            current &&
+            current.type === KeyringType.HdKeyring &&
+            typeof current.index === 'number'
+          ) {
+            slot = current.index
+          } else {
+            slot = 0
+          }
+        }
+        const active = origin.activeIndexes
+        accountIndex =
+          Array.isArray(active) && typeof active[slot] === 'number' ? active[slot]! : slot
+      }
+      const material = origin.getAccountXpubMaterial(accountIndex)
+      const originOpt = material.fingerprint
+        ? { origin: { fingerprint: material.fingerprint, path: material.accountPath } }
+        : {}
+
+      // Short hdPath (e.g. OW m/86'/0'/0'): wallet addresses are xpub/* — not xpub/0/*
+      if (material.xpubLevel === 'chain') {
+        const descriptor = hdAccountToDescriptor({
+          addressType,
+          ...originOpt,
+          xpub: material.xpub,
+          xpubLevel: 'chain',
+        })
+        const policy = parseDescriptor(descriptor).policy
+        return {
+          descriptor,
+          policy,
+          watchOnly: true,
+          xpub: material.xpub,
+          accountPath: material.accountPath,
+          ...(material.fingerprint ? { fingerprint: material.fingerprint } : {}),
+        }
+      }
+
+      const receive = hdAccountToDescriptor({
+        addressType,
+        ...originOpt,
+        xpub: material.xpub,
+        chain: 0,
+      })
+      const change = hdAccountToDescriptor({
+        addressType,
+        ...originOpt,
+        xpub: material.xpub,
+        chain: 1,
+      })
+      const policy = parseDescriptor(receive).policy
+      const descriptor = chain === 1 ? change : receive
+      return {
+        descriptor,
+        changeDescriptor: change,
+        policy,
+        watchOnly: true,
+        xpub: material.xpub,
+        accountPath: material.accountPath,
+        ...(material.fingerprint ? { fingerprint: material.fingerprint } : {}),
+      }
+    }
+
+    if (keyring.type === KeyringType.ColdWalletKeyring) {
+      const origin = keyringService.keyrings[keyring.index] as ColdWalletKeyring
+      if (!origin?.xpub) {
+        throw new Error('Cold wallet xpub missing')
+      }
+      const hdPath =
+        origin.hdPath ||
+        keyring.hdPath ||
+        ADDRESS_TYPES.find(a => a.value === keyring.addressType)?.hdPath
+      if (!hdPath) {
+        throw new Error('Cold wallet hdPath missing')
+      }
+      this._assertColdXpubPathDepth(origin.xpub, hdPath)
+      // Cold wallet xpubs in UniSat are receive-chain level (…/0).
+      // Use real fingerprint when stored; otherwise omit origin (never fake 00000000).
+      const fingerprint = origin.fingerprint
+      const descriptor = hdAccountToDescriptor({
+        addressType,
+        ...(fingerprint ? { origin: { fingerprint, path: hdPath } } : {}),
+        xpub: origin.xpub,
+        xpubLevel: 'chain',
+      })
+      const policy = parseDescriptor(descriptor).policy
+      return {
+        descriptor,
+        policy,
+        watchOnly: true,
+        xpub: origin.xpub,
+        accountPath: hdPath,
+        ...(fingerprint ? { fingerprint } : {}),
+      }
+    }
+
+    if (keyring.type === KeyringType.WatchAddressKeyring) {
+      const origin = keyringService.keyrings[keyring.index] as WatchAddressKeyring
+      if (!origin?.descriptor) {
+        throw new Error('This watch wallet has no stored descriptor to export')
+      }
+      const policy = parseDescriptor(origin.descriptor).policy
+      return {
+        descriptor: origin.descriptor,
+        ...(origin.changeDescriptor ? { changeDescriptor: origin.changeDescriptor } : {}),
+        policy,
+        watchOnly: true,
+      }
+    }
+
+    throw new Error('Descriptor export is only supported for HD, cold, and descriptor watch keyrings')
+  }
+
+  /** Policy chip data for approvals / receive UI */
+  getAccountPolicySummary = async (): Promise<PolicySummary> => {
+    try {
+      const { policy } = await this.exportAccountDescriptor()
+      return policy
+    } catch {
+      // Do not invent a "simple" policy when export is unsupported — chip should hide
+      return {
+        label: '',
+        kind: 'unknown',
+        isComplex: true,
+      }
+    }
+  }
+
+  /**
+   * Import a watch-only singlesig descriptor (no signing keys).
+   * Uses WatchAddressKeyring so signMethod=None (not Cold Wallet QR signing).
+   * Call previewDescriptor first so the UI can confirm addresses.
+   */
+  importDescriptor = async (
+    rawDescriptor: string,
+    alianName?: string,
+    accountCount = 20
+  ): Promise<WalletKeyring> => {
+    this._assertBitcoinDescriptorChain()
+    const parsed = this._parseImportDescriptor(rawDescriptor, accountCount)
+
+    const watchKeyring = new WatchAddressKeyring({
+      addresses: parsed.addresses,
+      descriptor: parsed.trimmed,
+      ...(parsed.changeDescriptor ? { changeDescriptor: parsed.changeDescriptor } : {}),
+      network: parsed.network,
+      receiveCount: parsed.addresses.length,
+    })
+    const originKeyring = await keyringService.addKeyring(watchKeyring, parsed.addressType)
+    const displayedKeyring = await keyringService.displayForKeyring(
+      originKeyring,
+      parsed.addressType,
+      keyringService.keyrings.length - 1
+    )
+    const keyring = this.displayedKeyringToWalletKeyring(
+      displayedKeyring,
+      keyringService.keyrings.length - 1
+    )
+    if (alianName) {
+      this.setKeyringAlianName(keyring, alianName)
+    }
+    await this.changeKeyring(keyring)
+    preferenceService.setShowSafeNotice(true)
+    return keyring
   }
 }
 export default new WalletController()

--- a/packages/wallet-background/tsup.config.ts
+++ b/packages/wallet-background/tsup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   treeshake: true,
   external: [
     'bitcoinjs-lib',
+    '@unisat/descriptor-service',
     '@unisat/keyring-service',
     '@unisat/permission-service',
     '@unisat/wallet-types',

--- a/packages/wallet-state/src/context/NavigationContext.tsx
+++ b/packages/wallet-state/src/context/NavigationContext.tsx
@@ -64,6 +64,8 @@ export type RouteParamList = {
   ExportPrivateKeyScreen: {
     account: Account
   }
+  ExportDescriptorScreen: undefined
+  ImportDescriptorScreen: undefined
   SwitchAccountScreen: undefined
   ReceiveScreen: undefined
   HistoryScreen: undefined

--- a/packages/wallet-state/src/context/WalletContext.tsx
+++ b/packages/wallet-state/src/context/WalletContext.tsx
@@ -132,6 +132,36 @@ export interface WalletController {
     password: string,
     account: { address: string; type: string }
   ): Promise<{ hex: string; wif: string }>
+  exportAccountDescriptor(opts?: {
+    keyringIndex?: number
+    accountSlot?: number
+    chain?: 0 | 1
+  }): Promise<{
+    descriptor: string
+    changeDescriptor?: string
+    policy: { label: string; kind: string; isComplex: boolean }
+    watchOnly: true
+    xpub?: string
+    accountPath?: string
+    fingerprint?: string
+  }>
+  previewDescriptor(
+    rawDescriptor: string,
+    accountCount?: number
+  ): Promise<{
+    policy: { label: string; kind: string; isComplex: boolean }
+    previewAddresses: string[]
+    addressType: AddressType
+    network: string
+    watchOnly: true
+  }>
+  canExportAccountDescriptor(): Promise<boolean>
+  getAccountPolicySummary(): Promise<{ label: string; kind: string; isComplex: boolean }>
+  importDescriptor(
+    rawDescriptor: string,
+    alianName?: string,
+    accountCount?: number
+  ): Promise<WalletKeyring>
   getMnemonics(
     password: string,
     keyring: WalletKeyring
@@ -190,7 +220,8 @@ export interface WalletController {
     addressType: AddressType,
     alianName?: string,
     hdPath?: string,
-    accountCount?: number
+    accountCount?: number,
+    fingerprint?: string
   ): Promise<WalletKeyring>
 
   deriveAccountsFromXpub(

--- a/packages/wallet-state/src/hooks/global.ts
+++ b/packages/wallet-state/src/hooks/global.ts
@@ -309,9 +309,17 @@ export function useCreateColdWalletCallback() {
       addressType: AddressType,
       alianName?: string,
       hdPath?: string,
-      accountCount?: number
+      accountCount?: number,
+      fingerprint?: string
     ) => {
-      await wallet.createKeyringWithColdWallet(xpub, addressType, alianName, hdPath, accountCount)
+      await wallet.createKeyringWithColdWallet(
+        xpub,
+        addressType,
+        alianName,
+        hdPath,
+        accountCount,
+        fingerprint
+      )
       dispatch(globalActions.update({ isUnlocked: true }))
     },
     [dispatch, wallet]

--- a/packages/wallet-state/src/hooks/settings.ts
+++ b/packages/wallet-state/src/hooks/settings.ts
@@ -201,7 +201,8 @@ export function useVersionInfo() {
   }
 
   // skip if current version is greater or equal to new version
-  if (currentVesion && newVersion) {
+  // compare-versions throws TypeError if either arg is not a string
+  if (typeof currentVesion === 'string' && typeof newVersion === 'string' && currentVesion && newVersion) {
     if (compareVersions(currentVesion, newVersion) >= 0) {
       skipped = true
     } else {

--- a/packages/wallet-state/src/ui-hooks/index.ts
+++ b/packages/wallet-state/src/ui-hooks/index.ts
@@ -47,6 +47,8 @@ export { useBRC20BalanceCardLogic, type BRC20BalanceCardProps } from './useBRC20
 
 export { useExportMnemonicsScreenLogic } from './useExportMnemonicsScreenLogic'
 export { useExportPrivateKeyScreenLogic } from './useExportPrivateKeyScreenLogic'
+export { useExportDescriptorScreenLogic } from './useExportDescriptorScreenLogic'
+export { useImportDescriptorScreenLogic } from './useImportDescriptorScreenLogic'
 export { useSendRunesScreenLogic } from './useSendRunesScreenLogic'
 
 export { useEditContactScreenLogic } from './useEditContactScreenLogic'

--- a/packages/wallet-state/src/ui-hooks/useExportDescriptorScreenLogic.ts
+++ b/packages/wallet-state/src/ui-hooks/useExportDescriptorScreenLogic.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useI18n, useNavigation, useTools, useWallet } from 'src/context'
+import { useCurrentAccount } from 'src/hooks'
+
+export function useExportDescriptorScreenLogic() {
+  const { t } = useI18n()
+  const nav = useNavigation()
+  const wallet = useWallet()
+  const tools = useTools()
+  const currentAccount = useCurrentAccount()
+
+  const [descriptor, setDescriptor] = useState('')
+  const [changeDescriptor, setChangeDescriptor] = useState('')
+  const [xpub, setXpub] = useState('')
+  const [accountPath, setAccountPath] = useState('')
+  const [fingerprint, setFingerprint] = useState('')
+  const [policyLabel, setPolicyLabel] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await wallet.exportAccountDescriptor()
+      setDescriptor(res.descriptor)
+      setChangeDescriptor(res.changeDescriptor || '')
+      setXpub(res.xpub || '')
+      setAccountPath(res.accountPath || '')
+      setFingerprint(res.fingerprint || '')
+      setPolicyLabel(res.policy?.label || '')
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }, [wallet, currentAccount?.key, currentAccount?.address])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const copy = (str: string) => {
+    tools.copyToClipboard(str)
+  }
+
+  return {
+    t,
+    loading,
+    descriptor,
+    changeDescriptor,
+    xpub,
+    accountPath,
+    fingerprint,
+    policyLabel,
+    error,
+    copy,
+    reload: load,
+    onClickBack: () => nav.goBack(),
+  }
+}

--- a/packages/wallet-state/src/ui-hooks/useImportDescriptorScreenLogic.ts
+++ b/packages/wallet-state/src/ui-hooks/useImportDescriptorScreenLogic.ts
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react'
+import { useI18n, useNavigation, useTools, useWallet } from 'src/context'
+
+const GAP_OPTIONS = [20, 50, 100] as const
+
+type Preview = {
+  policyLabel: string
+  previewAddresses: string[]
+}
+
+/**
+ * Two-step import: preview derived addresses → user confirms → persist watch keyring.
+ * Prevents silent switch to an attacker-supplied address set.
+ */
+export function useImportDescriptorScreenLogic() {
+  const { t } = useI18n()
+  const nav = useNavigation()
+  const wallet = useWallet()
+  const tools = useTools()
+
+  const [raw, setRaw] = useState('')
+  const [name, setName] = useState('')
+  const [accountCount, setAccountCount] = useState<number>(20)
+  const [error, setError] = useState('')
+  const [disabled, setDisabled] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [preview, setPreview] = useState<Preview | null>(null)
+
+  useEffect(() => {
+    setDisabled(!raw.trim() || busy)
+    setError('')
+    setPreview(null)
+  }, [raw, accountCount, busy])
+
+  const onPreview = async () => {
+    setBusy(true)
+    setError('')
+    setPreview(null)
+    try {
+      const res = await wallet.previewDescriptor(raw.trim(), accountCount)
+      setPreview({
+        policyLabel: res.policy?.label || '',
+        previewAddresses: res.previewAddresses || [],
+      })
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const onConfirmImport = async () => {
+    if (!preview) return
+    setBusy(true)
+    setError('')
+    try {
+      await wallet.importDescriptor(raw.trim(), name.trim() || undefined, accountCount)
+      tools.toastSuccess(t('success') || 'Success')
+      nav.navigate('MainScreen')
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const clearPreview = () => {
+    setPreview(null)
+    setError('')
+  }
+
+  return {
+    t,
+    raw,
+    setRaw,
+    name,
+    setName,
+    accountCount,
+    setAccountCount,
+    gapOptions: GAP_OPTIONS,
+    error,
+    disabled,
+    busy,
+    preview,
+    onPreview,
+    onConfirmImport,
+    clearPreview,
+    onClickBack: () => nav.goBack(),
+  }
+}

--- a/packages/wallet-state/src/ui-hooks/useImportDescriptorScreenLogic.ts
+++ b/packages/wallet-state/src/ui-hooks/useImportDescriptorScreenLogic.ts
@@ -26,24 +26,36 @@ export function useImportDescriptorScreenLogic() {
   const [busy, setBusy] = useState(false)
   const [preview, setPreview] = useState<Preview | null>(null)
 
+  // Enable button from input only — do NOT clear preview/error when `busy` flips
+  // (that used to wipe successful preview / error right after Check addresses).
   useEffect(() => {
     setDisabled(!raw.trim() || busy)
+  }, [raw, busy])
+
+  useEffect(() => {
     setError('')
     setPreview(null)
-  }, [raw, accountCount, busy])
+  }, [raw, accountCount])
 
   const onPreview = async () => {
+    if (!raw.trim() || busy) return
     setBusy(true)
     setError('')
     setPreview(null)
     try {
+      if (typeof wallet.previewDescriptor !== 'function') {
+        throw new Error(
+          'previewDescriptor is unavailable — rebuild wallet-background and reload the extension'
+        )
+      }
       const res = await wallet.previewDescriptor(raw.trim(), accountCount)
       setPreview({
         policyLabel: res.policy?.label || '',
         previewAddresses: res.previewAddresses || [],
       })
     } catch (e) {
-      setError((e as Error).message)
+      const msg = (e as Error)?.message || String(e)
+      setError(msg)
     } finally {
       setBusy(false)
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -809,6 +809,31 @@ importers:
         specifier: ^0.34.0
         version: 0.34.0(jsdom@27.4.0)
 
+  packages/descriptor-service:
+    dependencies:
+      '@bitcoinerlab/secp256k1':
+        specifier: ^1.0.5
+        version: 1.0.5
+      bip32:
+        specifier: ^4.0.0
+        version: 4.0.0
+      bitcoinjs-lib:
+        specifier: ^6.1.6
+        version: 6.1.6(patch_hash=endiwip2ry2tlbgod6aak5qlwa)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.8.0
+        version: 20.8.0
+      tsup:
+        specifier: ^7.2.0
+        version: 7.2.0(typescript@5.2.2)
+      typescript:
+        specifier: ^5.2.0
+        version: 5.2.2
+      vitest:
+        specifier: ^0.34.0
+        version: 0.34.0(jsdom@27.4.0)
+
   packages/keyring-service:
     dependencies:
       '@keystonehq/keystone-sdk':
@@ -1612,7 +1637,7 @@ packages:
       '@babel/traverse': 7.28.4
       '@babel/types': 7.28.4
       convert-source-map: 1.9.0
-      debug: 4.4.1
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4338,7 +4363,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
-      debug: 4.4.1
+      debug: 4.4.3
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -5058,7 +5083,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -5145,7 +5170,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.1
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7896,7 +7921,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.59.0(typescript@4.7.2)
       '@typescript-eslint/utils': 5.59.0(eslint@8.50.0)(typescript@4.7.2)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.50.0
       tsutils: 3.21.0(typescript@4.7.2)
       typescript: 4.7.2
@@ -7965,7 +7990,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.0
       '@typescript-eslint/visitor-keys': 5.59.0
-      debug: 4.4.1
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.2
@@ -9541,6 +9566,7 @@ packages:
 
   /bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    requiresBuild: true
     dependencies:
       file-uri-to-path: 1.0.0
     dev: true
@@ -9560,6 +9586,16 @@ packages:
   /bip174@2.1.1:
     resolution: {integrity: sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==}
     engines: {node: '>=8.0.0'}
+
+  /bip32@4.0.0:
+    resolution: {integrity: sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.1
+      typeforce: 1.18.0
+      wif: 2.0.6
+    dev: false
 
   /bip39@3.1.0:
     resolution: {integrity: sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==}
@@ -12833,6 +12869,7 @@ packages:
 
   /file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -13431,10 +13468,10 @@ packages:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
-      minimatch: 10.0.3
-      minipass: 7.1.2
+      minimatch: 10.2.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
-      path-scurry: 2.0.0
+      path-scurry: 2.0.2
     dev: true
 
   /glob@13.0.6:
@@ -13448,7 +13485,7 @@ packages:
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -16504,13 +16541,6 @@ packages:
   /minimalistic-crypto-utils@1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
-  /minimatch@10.0.3:
-    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
-    engines: {node: 20 || >=22}
-    dependencies:
-      '@isaacs/brace-expansion': 5.0.0
-    dev: true
-
   /minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
@@ -16627,11 +16657,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       yallist: 4.0.0
-    dev: true
-
-  /minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
     dev: true
 
   /minipass@7.1.3:
@@ -16773,6 +16798,7 @@ packages:
 
   /nan@2.23.0:
     resolution: {integrity: sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -17795,14 +17821,6 @@ packages:
     engines: {node: '>=16 || 14 >=14.18'}
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.3
-    dev: true
-
-  /path-scurry@2.0.0:
-    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
-    engines: {node: 20 || >=22}
-    dependencies:
-      lru-cache: 11.2.6
       minipass: 7.1.3
     dev: true
 


### PR DESCRIPTION
## Summary

UX polish adjacent to the descriptor stack (can review separately from PR1–PR5).

- **Watch-only balance card** — grey theme so watch accounts are visually distinct from spendable HD (gold).
- **Create-wallet backup confirm** — 12 or 24 words; verify **3 random positions** with **BIP-39 wordlist distractors**; answers matched by **phrase index** (duplicate words cannot bypass). Create path still uses encrypted `preMnemonics` after UI clears the phrase.
- **Switch account/keyring** — remove `rc-virtual-list` auto-scroll that hit max limitation noise.
- **Dev/connect** — harden `process.env.release` / channel and `useVersionInfo` so missing webpack `version` cannot crash dApp connect (`compare-versions` TypeError).

## Test plan (Done Local)

- [ ] Watch account → grey balance card; HD → gold
- [ ] Create wallet → 12 and 24; verify uses wordlist distractors (not other seed words); Continue only when all 3 positions correct
- [ ] Restore still goes isRestore → Step1_Import → full word grid; it never hits the 3-word challenge UI.
- [ ] dApp connect works with `version=1.7.17` / `channel=github` build

## Notes

- **Base:** `feat/desc-pr5-policy`.
