### PR TITLE
fix(deps): bump axios to ^1.15.1 to clear SSRF / credential-leak advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "packageManager": "pnpm@8.6.0",
   "pnpm": {
     "overrides": {
-      "react-redux": "^8.0.5"
+      "axios": "^1.15.1"
     },
     "patchedDependencies": {
       "bitcore-lib@10.0.0": "patches/bitcore-lib@10.0.0.patch",

--- a/packages/babylon-service/package.json
+++ b/packages/babylon-service/package.json
@@ -45,7 +45,7 @@
   "author": "UniSat",
   "license": "MIT",
   "dependencies": {
-    "axios": "^1.6.0",
+    "axios": "^1.15.1",
     "qs": "^6.11.0",
     "@babylonlabs-io/babylon-proto-ts": "0.0.3-canary.5",
     "@cosmjs/proto-signing": "^0.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  react-redux: ^8.0.5
+  axios: ^1.15.1
 
 patchedDependencies:
   bitcoinjs-lib@6.1.6:
@@ -132,7 +132,7 @@ importers:
         version: 0.5.3(react-refresh@0.11.0)(webpack-dev-server@4.6.0)(webpack@5.64.4)
       '@reduxjs/toolkit':
         specifier: ^1.9.2
-        version: 1.9.2(react-redux@8.0.5)(react@18.2.0)
+        version: 1.9.2(react-redux@8.0.1)(react@18.2.0)
       '@sentry/browser':
         specifier: ^6.19.7
         version: 6.19.7
@@ -434,8 +434,8 @@ importers:
         specifier: ^3.15.1
         version: 3.15.1(react-dom@18.2.0)(react@18.2.0)
       react-redux:
-        specifier: ^8.0.5
-        version: 8.0.5(@types/react-dom@18.2.17)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.1)
+        specifier: 8.0.1
+        version: 8.0.1(@types/react-dom@18.2.17)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.1)
       react-refresh:
         specifier: ^0.11.0
         version: 0.11.0
@@ -447,7 +447,7 @@ importers:
         version: 4.2.1
       redux-devtools:
         specifier: ^3.7.0
-        version: 3.7.0(react-redux@8.0.5)(react@18.2.0)(redux@4.2.1)
+        version: 3.7.0(react-redux@8.0.1)(react@18.2.0)(redux@4.2.1)
       redux-localstorage-simple:
         specifier: ^2.5.1
         version: 2.5.1
@@ -716,8 +716,8 @@ importers:
         specifier: ^1.3.0
         version: 1.8.0
       axios:
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.15.1
+        version: 1.15.1
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1375,8 +1375,8 @@ importers:
         specifier: ^11.16.9
         version: 11.16.9(i18next@21.8.1)(react-dom@18.2.0)(react@18.2.0)
       react-redux:
-        specifier: ^8.0.5
-        version: 8.0.5(@types/react-dom@18.2.17)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.1)
+        specifier: 8.0.1
+        version: 8.0.1(@types/react-dom@18.2.17)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.1)
       react-router-dom:
         specifier: ^6.3.0
         version: 6.3.0(react-dom@18.2.0)(react@18.2.0)
@@ -1386,7 +1386,7 @@ importers:
     devDependencies:
       '@reduxjs/toolkit':
         specifier: ^1.9.2
-        version: 1.9.2(react-redux@8.0.5)(react@18.2.0)
+        version: 1.9.2(react-redux@8.0.1)(react@18.2.0)
       '@testing-library/react':
         specifier: ^13.2.0
         version: 13.2.0(react-dom@18.2.0)(react@18.2.0)
@@ -4705,7 +4705,7 @@ packages:
       '@cosmjs/socket': 0.33.1
       '@cosmjs/stream': 0.33.1
       '@cosmjs/utils': 0.33.1
-      axios: 1.6.0
+      axios: 1.15.1
       readonly-date: 1.0.0
       xstream: 11.14.0
     transitivePeerDependencies:
@@ -6780,7 +6780,7 @@ packages:
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
     dev: false
 
-  /@reduxjs/toolkit@1.9.2(react-redux@8.0.5)(react@18.2.0):
+  /@reduxjs/toolkit@1.9.2(react-redux@8.0.1)(react@18.2.0):
     resolution: {integrity: sha512-5ZAZ7hwAKWSii5T6NTPmgIBUqyVdlDs+6JjThz6J6dmHLDm6zCzv2OjHIFAi3Vvs1qjmXU0bm6eBojukYXjVMQ==}
     peerDependencies:
       react: ^16.9.0 || ^17.0.0 || ^18
@@ -6793,7 +6793,7 @@ packages:
     dependencies:
       immer: 9.0.21
       react: 18.2.0
-      react-redux: 8.0.5(@types/react-dom@18.2.17)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.1)
+      react-redux: 8.0.1(@types/react-dom@18.2.17)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.1)
       redux: 4.2.1
       redux-thunk: 2.4.2(redux@4.2.1)
       reselect: 4.1.8
@@ -6857,7 +6857,7 @@ packages:
   /@sats-connect/core@0.2.2:
     resolution: {integrity: sha512-nl3zPnV1UBllYAniDfhM/oSFGQ2qy4cCg1YwxJZ+RQMwlTMrVh2f3lJ//dIIo9RgQPrtHpwrAaaWW0VpfqDQbg==}
     dependencies:
-      axios: 1.7.4
+      axios: 1.15.1
       bitcoin-address-validation: 2.2.3
       buffer: 6.0.3
       jsontokens: 4.0.1
@@ -9101,35 +9101,14 @@ packages:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  /axios@1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+  /axios@1.15.1:
+    resolution: {integrity: sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==}
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
-    dev: true
-
-  /axios@1.6.0:
-    resolution: {integrity: sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==}
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /axios@1.7.4:
-    resolution: {integrity: sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==}
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-    dev: true
 
   /babel-jest@27.4.2(@babel/core@7.20.2):
     resolution: {integrity: sha512-MADrjb3KBO2eyZCAc6QaJg6RT5u+6oEdDyHO5HEalnpwQ6LrhTsQF2Kj1Wnz2t6UPXIXPk18dSXXOT0wF5yTxA==}
@@ -9541,6 +9520,7 @@ packages:
 
   /bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    requiresBuild: true
     dependencies:
       file-uri-to-path: 1.0.0
     dev: true
@@ -12833,6 +12813,7 @@ packages:
 
   /file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -13074,6 +13055,7 @@ packages:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+    dev: true
 
   /form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -13084,7 +13066,6 @@ packages:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
-    dev: true
 
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -16773,6 +16754,7 @@ packages:
 
   /nan@2.23.0:
     resolution: {integrity: sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -17125,7 +17107,7 @@ packages:
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.2
       '@zkochan/js-yaml': 0.0.7
-      axios: 1.13.5
+      axios: 1.15.1
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
       cliui: 8.0.1
@@ -18944,8 +18926,9 @@ packages:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  /proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  /proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   /prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
@@ -19829,8 +19812,8 @@ packages:
       szfe-tools: 0.0.0-beta.7
     dev: false
 
-  /react-redux@8.0.5(@types/react-dom@18.2.17)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.1):
-    resolution: {integrity: sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==}
+  /react-redux@8.0.1(@types/react-dom@18.2.17)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.1):
+    resolution: {integrity: sha512-LMZMsPY4DYdZfLJgd7i79n5Kps5N9XVLCJJeWAaPYTV+Eah2zTuBjTxKtNEbjiyitbq80/eIkm55CYSLqAub3w==}
     peerDependencies:
       '@types/react': ^16.8 || ^17.0 || ^18.0
       '@types/react-dom': ^16.8 || ^17.0 || ^18.0
@@ -20069,7 +20052,7 @@ packages:
       symbol-observable: 1.2.0
     dev: false
 
-  /redux-devtools@3.7.0(react-redux@8.0.5)(react@18.2.0)(redux@4.2.1):
+  /redux-devtools@3.7.0(react-redux@8.0.1)(react@18.2.0)(redux@4.2.1):
     resolution: {integrity: sha512-Lnx3UX7mnJij2Xs+RicPK1GyKkbuodrCKtfYmJsN603wC0mc99W//xCAskGVNmRhIXg4e57m2k1CyX0kVzCsBg==}
     deprecated: Package moved to @redux-devtools/core.
     peerDependencies:
@@ -20081,7 +20064,7 @@ packages:
       lodash: 4.17.21
       prop-types: 15.8.1
       react: 18.2.0
-      react-redux: 8.0.5(@types/react-dom@18.2.17)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.1)
+      react-redux: 8.0.1(@types/react-dom@18.2.17)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)(redux@4.2.1)
       redux: 4.2.1
       redux-devtools-instrument: 1.10.0(redux@4.2.1)
     dev: false


### PR DESCRIPTION
Summary
The production tree resolves axios to 1.6.0 and 1.7.4, both below the SSRF / credential-leak fix floors (>=1.8.2, and the NO_PROXY/loopback hardening in >=1.15.1).

Affected path: packages/babylon-service/src/api/apiWrapper.ts builds url = baseUrl + path and calls axios.get/post for Babylon staking network calls. baseUrl is supplied from config/network selection and is therefore attacker/config-influenceable, making the vulnerable axios a real SSRF / header-leak surface.

Change
- Bump axios in packages/babylon-service to ^1.15.1.
- Add a root pnpm.overrides for axios so the entire workspace resolves 1.15.1.
- Drop-in upgrade, no API/usage change.

Verification
Lockfile now resolves axios@1.15.1 only (no remaining <1.8.2 copies).